### PR TITLE
FIX: decompress files despite possible mis-identification

### DIFF
--- a/src/compression/Decompressor.cpp
+++ b/src/compression/Decompressor.cpp
@@ -122,7 +122,8 @@ bool Decompressor::decompress(const PPSystemString& outFileName, Hints hint)
 		if (decompressors.get(i)->identify())
 		{
 			result = decompressors.get(i)->decompress(outFileName, hint);
-			break;
+			if (result)
+				break;
 		}
 	}
 	


### PR DESCRIPTION
Currently, the decompressor searches the list of decompression modules and asks each to identify whether they can decompress the given file, stopping at the first one which says "yes". Since identification is based on heuristics, it sometimes happens that a decompression module mistakenly states that it can decompress a file but then actually fails decompressing it. MilkyTracker then claims the file is corrupt even though a different decompression module could have been successful.

This patch fixes the behavior to simply continue iterating the list of decompressors if one fails to load the file. This should fix the loading of some .umx files.
