### PR TITLE
Patch for Issue #48

### DIFF
--- a/src/tracker/EnvelopeEditorControl.cpp
+++ b/src/tracker/EnvelopeEditorControl.cpp
@@ -726,6 +726,10 @@ pp_int32 EnvelopeEditorControl::dispatchEvent(PPEvent* event)
 			
 			else if (params->deltaY)
 			{
+				if (invertMWheelZoom)
+				{
+					params->deltaY = -params->deltaY;
+				}
 				setScale(params->deltaY > 0 ? xScale << 1 : xScale >> 1);
 				parentScreen->paintControl(this);
 			}

--- a/src/tracker/EnvelopeEditorControl.cpp
+++ b/src/tracker/EnvelopeEditorControl.cpp
@@ -705,18 +705,22 @@ pp_int32 EnvelopeEditorControl::dispatchEvent(PPEvent* event)
 			
 			// Horizontal scrolling takes priority over vertical scrolling (zooming) and is
 			// mutually exclusive so that we are less likely to accidentally zoom while scrolling
-			if (params->deltaX)
+			// For compatibility for mice without horizontal scroll, SHIFT + vertical scroll is
+			// treated as a synonym for horizontal scroll.
+			bool shiftHeld = (::getKeyModifier() & KeyModifierSHIFT);
+			if (params->deltaX || (params->deltaY && shiftHeld))
 			{
+				pp_int32 delta = shiftHeld? params->deltaY : params->deltaX;
 				// Deltas greater than 1 generate multiple events for scroll acceleration
-				PPEvent e = params->deltaX > 0 ? PPEvent(eBarScrollDown) : PPEvent(eBarScrollUp);
+				PPEvent e = delta > 0 ? PPEvent(eBarScrollDown) : PPEvent(eBarScrollUp);
 				
-				params->deltaX = abs(params->deltaX);
-				params->deltaX = params->deltaX > 20 ? 20 : params->deltaX;
+				delta = abs(delta);
+				delta = delta > 20 ? 20 : delta;
 				
-				while (params->deltaX)
+				while (delta)
 				{
 					handleEvent(reinterpret_cast<PPObject*>(hScrollbar), &e);
-					params->deltaX--;
+					delta--;
 				}
 			}
 			

--- a/src/tracker/EnvelopeEditorControl.h
+++ b/src/tracker/EnvelopeEditorControl.h
@@ -62,6 +62,7 @@ private:
 	pp_int32 visibleWidth;
 	pp_int32 visibleHeight;
 	bool hasDragged;
+	bool invertMWheelZoom;
 
 	// selection
 	pp_int32 selectionTicker;
@@ -106,6 +107,8 @@ public:
 	EnvelopeEditor* getEnvelopeEditor() { return envelopeEditor; }
 	
 	void setShowVCenter(bool b) { showVCenter = b; }
+
+	void setInvertMWheelZoom(bool invert) { invertMWheelZoom = invert; }
 
 	void paintGrid(PPGraphicsAbstract* graphics, pp_int32 xOffset, pp_int32 yOffset);
 	

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -1045,6 +1045,10 @@ selectingAndResizing:
 			
 			else if (params->deltaY)
 			{
+				if (invertMWheelZoom)
+				{
+					params->deltaY = -params->deltaY;
+				}
 				params->deltaY > 0 ? scrollWheelZoomOut(&params->pos) : scrollWheelZoomIn(&params->pos);
 			}
 			

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -1023,19 +1023,23 @@ selectingAndResizing:
 			TMouseWheelEventParams* params = (TMouseWheelEventParams*)event->getDataPtr();
 
 			// Horizontal scrolling takes priority over vertical scrolling (zooming) and is
-			// mutually exclusive so that we are less likely to accidentally zoom while scrolling
-			if (params->deltaX)
+			// mutually exclusive so that we are less likely to accidentally zoom while scrolling.
+			// For compatibility for mice without horizontal scroll, SHIFT + vertical scroll is
+			// treated as a synonym for horizontal scroll.
+			bool shiftHeld = (::getKeyModifier() & KeyModifierSHIFT);
+			if (params->deltaX || (params->deltaY && shiftHeld))
 			{
+				pp_int32 delta = shiftHeld? params->deltaY : params->deltaX;
 				// Deltas greater than 1 generate multiple events for scroll acceleration
-				PPEvent e = params->deltaX > 0 ? PPEvent(eBarScrollDown) : PPEvent(eBarScrollUp);
+				PPEvent e = delta > 0 ? PPEvent(eBarScrollDown) : PPEvent(eBarScrollUp);
 				
-				params->deltaX = abs(params->deltaX);
-				params->deltaX = params->deltaX > 20 ? 20 : params->deltaX;
+				delta = abs(delta);
+				delta = delta > 20 ? 20 : delta;
 				
-				while (params->deltaX)
+				while (delta)
 				{
 					handleEvent(reinterpret_cast<PPObject*>(hScrollbar), &e);
-					params->deltaX--;
+					delta--;
 				}
 			}
 			

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -95,6 +95,7 @@ private:
 	bool drawMode;
 
 	bool hasDragged;
+	bool invertMWheelZoom;
 
 	// selection
 	pp_int32 selectionTicker;
@@ -190,6 +191,8 @@ public:
 
 		notifyUpdate();
 	}
+
+	void setInvertMWheelZoom(bool invert) { invertMWheelZoom = invert; }
 	
 	void showAll();
 

--- a/src/tracker/SectionSettings.cpp
+++ b/src/tracker/SectionSettings.cpp
@@ -237,6 +237,8 @@ enum ControlIDs
 	
 	STATICTEXT_SETTINGS_SCOPESAPPEARANCE,
 	RADIOGROUP_SETTINGS_SCOPESAPPEARANCE,
+
+	CHECKBOX_SETTINGS_INVERTMWHEELZOOM,
 	
 	// Page V (only on desktop version)
 	RADIOGROUP_SETTINGS_STOPBACKGROUNDBEHAVIOUR,
@@ -260,6 +262,7 @@ enum ControlIDs
 	PAGE_MISC_1,
 	PAGE_MISC_2,
 	PAGE_MISC_3,
+	PAGE_MISC_4,
 
 	PAGE_TABS_1,
 	PAGE_TABS_2,
@@ -1545,6 +1548,40 @@ public:
 	
 };
 
+class TabPageMisc_4 : public TabPage
+{
+public:
+	TabPageMisc_4(pp_uint32 id, SectionSettings& sectionSettings) :
+		TabPage(id, sectionSettings)
+	{
+	}
+
+	virtual void init(PPScreen* screen)
+	{
+		pp_int32 x = 0;
+		pp_int32 y = 0;
+
+		container = new PPTransparentContainer(id, screen, this, PPPoint(x, y), PPSize(PageWidth,PageHeight));
+
+		pp_int32 x2 = x;
+		pp_int32 y2 = y;
+
+		container->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x2 + 2, y2), "Other", true, true));
+		y2+=4+11;
+
+		container->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x2 + 2, y2), "Inv. mwheel zoom:", true));
+		container->addControl(new PPCheckBox(CHECKBOX_SETTINGS_INVERTMWHEELZOOM, screen, this, PPPoint(x2 + 4 + 17*8 + 4, y2-1)));
+
+		y2+=12;
+	}
+
+	virtual void update(PPScreen* screen, TrackerSettingsDatabase* settingsDatabase, ModuleEditor& moduleEditor)
+	{
+		pp_int32 v = settingsDatabase->restore("INVERTMWHEELZOOM")->getIntValue();
+		static_cast<PPCheckBox*>(container->getControlByID(CHECKBOX_SETTINGS_INVERTMWHEELZOOM))->checkIt(v!=0);
+	}
+};
+
 class TabPageTabs_1 : public TabPage
 {
 public:
@@ -2093,6 +2130,15 @@ pp_int32 SectionSettings::handleEvent(PPObject* sender, PPEvent* event)
 				tracker.settingsDatabase->store("SCOPES", value);
 				update();
 				break;				
+			}
+
+			case CHECKBOX_SETTINGS_INVERTMWHEELZOOM:
+			{
+				if (event->getID() != eCommand)
+					break;
+
+				tracker.settingsDatabase->store("INVERTMWHEELZOOM", (pp_int32)reinterpret_cast<PPCheckBox*>(sender)->isChecked());
+				break;
 			}
 
 			//case CHECKBOX_SETTINGS_FOLLOWSONG:
@@ -2648,6 +2694,7 @@ void SectionSettings::init(pp_int32 x, pp_int32 y)
 	tabPages.get(3)->add(new TabPageMisc_1(PAGE_MISC_1, *this));
 	tabPages.get(3)->add(new TabPageMisc_2(PAGE_MISC_2, *this));
 	tabPages.get(3)->add(new TabPageMisc_3(PAGE_MISC_3, *this));
+	tabPages.get(3)->add(new TabPageMisc_4(PAGE_MISC_4, *this));
 
 #ifndef __LOWRES__
 	tabPages.get(4)->add(new TabPageTabs_1(PAGE_TABS_1, *this));

--- a/src/tracker/TrackerSettings.cpp
+++ b/src/tracker/TrackerSettings.cpp
@@ -207,6 +207,8 @@ void Tracker::buildDefaultSettings()
 	settingsDatabase->store("MULTICHN_RECORDKEYOFF", 1);
 	// disable note delay recording
 	settingsDatabase->store("MULTICHN_RECORDNOTEDELAY", 0);
+	// Invert mousewheel zoom?  (normally wheelup zooms out: if inverted, wheelup zooms in)
+	settingsDatabase->store("INVERTMWHEELZOOM", 0);
 
 	// ---------- Tabs ---------- 
 	// Control playing of background tabs
@@ -566,6 +568,11 @@ void Tracker::applySettingByKey(PPDictionaryKey* theKey, TMixerSettings& setting
 	else if (theKey->getKey().compareTo("MULTICHN_RECORDNOTEDELAY") == 0)
 	{
 		recorderLogic->setRecordNoteDelay(v2 != 0);
+	}
+	else if (theKey->getKey().compareTo("INVERTMWHEELZOOM") == 0)
+	{
+		sectionSamples->getSampleEditorControl()->setInvertMWheelZoom(v2 != 0);
+		sectionInstruments->getEnvelopeEditorControl()->setInvertMWheelZoom(v2 != 0);
 	}
 	// ----------------------- Tabs -------------------------
 	else if (theKey->getKey().compareTo("TABS_STOPBACKGROUNDBEHAVIOUR") == 0)


### PR DESCRIPTION
After reading Raina's enhancement request (Issue #48), I realized that this is also a feature that I've wanted for many years so I can re-use muscle memory used on other Windows programs.  I went ahead and implemented it in a fork.

Changes:
1)  Added horizontal scroll to the envelope and sample editors, via SHIFT+Mousewheel.  I chose SHIFT as the modifier because this is a common shortcut for horizontal scroll used in many other programs.  This appears to work fine.  My only concern is that the scroll increment seems a little small in the instrument editor (i.e. you have to roll the wheel a lot to get it to scroll a reasonable distance).  I left it alone because I wanted to stay consistent with the existing horizontal scroll feature, for those with horizontal mousewheels on their mice.  If other maintainers are OK with special-casing the instrument editor's new SHIFT+Mousewheel to scroll 2x or 4x faster than it presently does, I suggest doing so.

2) Added a setting to invert the direction of the mousewheel zoom in the instrument and sample editors.  As usual, this is a checkbox in the "Config" menu.  I placed it in the "Misc" section, which was already pretty full, so the checkbox resides in a fourth page off to the right.  I've checked that the setting seems to persist correctly when MilkyTracker is exited and restarted.  Note the addition to the configuration file in TrackerSettings.cpp.

Please let me know if this patch is acceptable, and whether there is more work I will need to do before you accept it into trunk.
