### PR TITLE
Add continuous integration build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ MilkyTracker - Cross-Platform XM Tracker
 ========================================
 
 [![Travis Build Status](https://travis-ci.org/milkytracker/MilkyTracker.svg?branch=master)](https://travis-ci.org/milkytracker/MilkyTracker)
-[![AppVeyor Build Status]](https://ci.appveyor.com/api/projects/status/github/milkytracker/MilkyTracker?branch=master&svg=true)](https://ci.appveyor.com/project/Deltafire/milkytracker)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/milkytracker/MilkyTracker?branch=master&svg=true)](https://ci.appveyor.com/project/Deltafire/milkytracker)
 
 MilkyTracker is an multi-platform music application for creating .MOD
 and .XM module files. It attempts to recreate the module replay and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 MilkyTracker - Cross-Platform XM Tracker
 ========================================
 
+[![Travis Build Status](https://travis-ci.org/milkytracker/MilkyTracker.svg?branch=master)](https://travis-ci.org/milkytracker/MilkyTracker)
+[![AppVeyor Build Status]](https://ci.appveyor.com/api/projects/status/github/milkytracker/MilkyTracker?branch=master&svg=true)](https://ci.appveyor.com/project/Deltafire/milkytracker)
+
 MilkyTracker is an multi-platform music application for creating .MOD
 and .XM module files. It attempts to recreate the module replay and
 user experience of the popular DOS program Fasttracker II, with


### PR DESCRIPTION
Added badges for build status of Travis CI and
AppVeyor to the front page README, giving a
quick overview.

Please review the URLs. In particular the AppVeyor project URL was just found by googling.