### PR TITLE
Issue #82 - New Equalizer Constants

### DIFF
--- a/src/tracker/EQConstants.cpp
+++ b/src/tracker/EQConstants.cpp
@@ -20,52 +20,46 @@
  *
  */
 
-/*  
- * bullshit trial and error values following because nobody knows 
- * how the EQ actually works
- *
- */
-
 #include "EQConstants.h"
 
 const float EQConstants::EQ3bands[3] = 
 {
-	80.0f,
-	2500.0f,
-	12000.0f
+	0x1.0558p+5f,  // 32     Hz
+	0x1.0558p+9f,  // 522    Hz
+	0x1.0558p+12f, // 4181.5 Hz
 };
 
 const float EQConstants::EQ3bandwidths[3] = 
 {
-	2500.0f*0.25f,
-	2500.0f*0.5f,
-	2500.0f
+	170.0f,
+	600.0f,
+	1000.0f
 };
 
 const float EQConstants::EQ10bands[10] = 
 {
-	31.25f,
-	62.5f,
-	125.0f,
-	250.0f,
-	500.0f,
-	1000.0f,
-	2000.0f,
-	4000.0f,
-	8000.0f,
-	16000.0f
+	0x1.0558p+3f,  // 8      Hz
+	0x1.0558p+4f,  // 16     Hz
+	0x1.0558p+5f,  // 32     Hz
+	0x1.0558p+6f,  // 65     Hz
+	0x1.0558p+7f,  // 130    Hz
+	0x1.0558p+8f,  // 261    Hz
+	0x1.0558p+9f,  // 522    Hz
+	0x1.0558p+10f, // 1     kHz
+	0x1.0558p+11f, // 2     kHz
+	0x1.0558p+12f, // 4181.5 Hz
 };
 
 const float EQConstants::EQ10bandwidths[10] = 
 {
-	23.44f*0.25f,
-	46.87f*0.30f,
-	93.75f*0.35f,
-	187.5f*0.40f,
-	375.0f*0.45f,
-	750.0f*0.50f,
-	1500.0f*0.55f,
-	3000.0f*0.50f,
-	6000.0f*0.30f,
-	12000.0f*0.25f
+	16,
+	0x1.0558p+3f*1.5f,
+	0x1.0558p+4f*1.5f,
+	0x1.0558p+5f*1.5f,
+	0x1.0558p+6f*1.5f,
+	0x1.0558p+7f*1.5f,
+	0x1.0558p+8f*1.0f,
+	0x1.0558p+9f*1.0f,
+	600.0f,
+	800.0f
 };

--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -2120,8 +2120,7 @@ void SampleEditor::tool_eqSample(const FilterParameters* par)
 	
 	prepareUndo();	
 	
-	float c4spd = getc4spd(sample->relnote, sample->finetune);
-	float scale = c4spd / 44100.0f;
+	float c4spd = 8363; // there really should be a global constant for this
 	
 	Equalizer** eqs = new Equalizer*[par->getNumParameters()];
 	
@@ -2131,7 +2130,7 @@ void SampleEditor::tool_eqSample(const FilterParameters* par)
 		for (pp_int32 i = 0; i < par->getNumParameters(); i++)
 		{
 			eqs[i] = new Equalizer();
-			eqs[i]->CalcCoeffs(EQConstants::EQ3bands[i]*scale, EQConstants::EQ3bandwidths[i]*scale, c4spd, Equalizer::CalcGain(par->getParameter(i).floatPart));
+			eqs[i]->CalcCoeffs(EQConstants::EQ3bands[i], EQConstants::EQ3bandwidths[i], c4spd, Equalizer::CalcGain(par->getParameter(i).floatPart));
 		}
 	}
 	// ten band EQ
@@ -2140,7 +2139,7 @@ void SampleEditor::tool_eqSample(const FilterParameters* par)
 		for (pp_int32 i = 0; i < par->getNumParameters(); i++)
 		{
 			eqs[i] = new Equalizer();
-			eqs[i]->CalcCoeffs(EQConstants::EQ10bands[i]*scale, EQConstants::EQ10bandwidths[i]*scale, c4spd, Equalizer::CalcGain(par->getParameter(i).floatPart));
+			eqs[i]->CalcCoeffs(EQConstants::EQ10bands[i], EQConstants::EQ10bandwidths[i], c4spd, Equalizer::CalcGain(par->getParameter(i).floatPart));
 		}
 	}
 	else


### PR DESCRIPTION
See Issue #82 
I implemented the modified Equalizer invocation with correct frequency ranges.

The Equalizer behaves a bit nonlinear in respect to bandwidth settings, especially with very high center frequencies close to the Nyquist frequency, because of that, the bandwidth values had to be manually tuned to get the desired effect.

This is the plot for a single pass of the 3 band equalizer in "none shall pass" mode. The result is a reduction from -48db to -60db (12 db reduction) across the whole spectrum
![fa_fixed_3channel](https://cloud.githubusercontent.com/assets/569222/24823822/1f1c260a-1c03-11e7-8ad5-11d923bfed8a.png)
 
And the same for 10 channel ( single filter pass) - it might be possible to tune that a bit more to get the line even flatter especially around very low frequencies, but the overall behaviour looks pretty good
![fa_fixed_10channel](https://cloud.githubusercontent.com/assets/569222/24823843/4876e7b0-1c03-11e7-8d47-fddbfae32ac0.png)

