### PR TITLE
Improvement #85 Modulation

### DIFF
--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -249,6 +249,8 @@ public:
 	void cropSample();
 	void clearSample();
 	void mixPasteSample();
+	void AMPasteSample();
+	void FMPasteSample();
 	void convertSampleResolution(bool convert);
 
 	// remember to stop playing before using this
@@ -313,6 +315,8 @@ public:
 	void tool_cropSample(const FilterParameters* par);
 	void tool_clearSample(const FilterParameters* par);
 	void tool_mixPasteSample(const FilterParameters* par);
+	void tool_AMPasteSample(const FilterParameters* par);
+	void tool_FMPasteSample(const FilterParameters* par);
 	
 	// convert sample resolution
 	void tool_convertSampleResolution(const FilterParameters* par);

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -158,6 +158,8 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	editMenuControl->addEntry("Copy", MenuCommandIDCopy);
 	editMenuControl->addEntry("Paste", MenuCommandIDPaste);
 	editMenuControl->addEntry("Mix-Paste", MenuCommandIDMixPaste);
+	editMenuControl->addEntry("AM-Paste", MenuCommandIDAMPaste);
+	editMenuControl->addEntry("FM-Paste", MenuCommandIDFMPaste);
 	editMenuControl->addEntry("Crop", MenuCommandIDCrop);
 	editMenuControl->addEntry("Range all", MenuCommandIDSelectAll);
 	editMenuControl->addEntry(seperatorStringMed, -1);
@@ -1650,6 +1652,8 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	editMenuControl->setState(MenuCommandIDRedo, !sampleEditor->canRedo());
 	editMenuControl->setState(MenuCommandIDPaste, !sampleEditor->canPaste());
 	editMenuControl->setState(MenuCommandIDMixPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
+	editMenuControl->setState(MenuCommandIDAMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
+	editMenuControl->setState(MenuCommandIDFMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	editMenuControl->setState(MenuCommandIDCopy, !hasValidSelection());
 	editMenuControl->setState(MenuCommandIDCut, !hasValidSelection());
 	editMenuControl->setState(MenuCommandIDCrop, !hasValidSelection());
@@ -1711,6 +1715,16 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 		// mix-paste
 		case MenuCommandIDMixPaste:
 			sampleEditor->mixPasteSample();
+			break;
+
+		// AM-paste
+		case MenuCommandIDAMPaste:
+			sampleEditor->AMPasteSample();
+			break;
+
+		// FM-paste
+		case MenuCommandIDFMPaste:
+			sampleEditor->FMPasteSample();
 			break;
 
 		// crop

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -274,6 +274,8 @@ private:
 	{
 		MenuCommandIDCrop = 99,
 		MenuCommandIDMixPaste,
+		MenuCommandIDAMPaste,
+		MenuCommandIDFMPaste,
 		MenuCommandIDNormalize,
 		MenuCommandIDVolumeBoost,
 		MenuCommandIDVolumeFade,


### PR DESCRIPTION
Allow to AM and FM modulate clipboard content with the current selection

This adds two more menu entries in the Sample Editor (under Mix-Paste)
AM-Paste and FM-Paste

AM-Paste works like Mix-Paste, except it multiplies the data from the clipboard with the selection. The result is an amplitude modulation of the two data-sets. This can be used to create fast-paced envelopes and sound effects.

FM-Paste is the bastard cousin of AM-paste. It replaces the pattern with the clipboard contents but frequency modulates them with the previous sample data. This can be used to create fast-paced pitch-changes and sound effects.



I'm adding a few screenshots:

AM-Paste usage:
You take one sample into the clipboard
![am-source](https://cloud.githubusercontent.com/assets/569222/24833382/d184e7f4-1cc7-11e7-8955-b08eb3843573.png)

Then choose another. The low frequency sample controls the envelope of the high frequency sample. The order doesn't matter (you can paste the envelope into the hf sample, or the hs sample over the envelope, same result)
![am-destination](https://cloud.githubusercontent.com/assets/569222/24833429/063cc7c8-1cc8-11e7-9b6c-d19e2af45140.png)

both samples get scaled to match each other's length just like with Mix-Paste

effect of AM-paste:
![am-result](https://cloud.githubusercontent.com/assets/569222/24833431/137149b4-1cc8-11e7-90ed-adc8d05a7e29.png)


FM-paste works differently. one sample changes the frequency of the other. As such you should choose a (preferably looping), high frequency sample into the clipboard:
![fm-source](https://cloud.githubusercontent.com/assets/569222/24833436/45c5b634-1cc8-11e7-8da5-220d8f1fba22.png)
(a 32byte sawtooth works well)

then you need a larger destination sample, with the frequency-envelope for the source to be pasted in.
the maximum modulation range of the frequency is +4 octaves (at +1) to - 4 octaves (at -1)
![fm-destination](https://cloud.githubusercontent.com/assets/569222/24833445/c397be4a-1cc8-11e7-8952-dfa76c17581c.png)
this ramp down will cause a linear frequency slide, and since it's only a second long, it will be a rapid slide, a "zap!!!" sound effect

the source sample is pasted with a frequency(pitch) modulated by the destination sample at each point, and repeated as necessary to fill the entire area
![fm-result](https://cloud.githubusercontent.com/assets/569222/24833454/fafd22ee-1cc8-11e7-826a-be74bfc3f943.png)

this is really great for making ones own digital percussion effect samples.