### PR TITLE
Fixes to GUS patch loading, issue #51

### DIFF
--- a/src/milkyplay/XIInstrument.cpp
+++ b/src/milkyplay/XIInstrument.cpp
@@ -326,6 +326,10 @@ static mp_sint32 gusFreqToFT2Note(mp_dword freq)
 		/* Octave 8 */  4186073, 4434930, 4698645, 4978041, 5274051, 5587663, 5919922, 6271939, 6644889, 7040015, 7458636, 7902150, 0xFFFFFFFF
 	};
 
+	if (scale_table[0] > freq)
+	{
+		return 0-12;
+	}
 	for (mp_uint32 no = 0; no < sizeof(scale_table)/sizeof(mp_dword)-1; no++)
 	{
 		if (scale_table[no] <= freq && 

--- a/src/milkyplay/XIInstrument.cpp
+++ b/src/milkyplay/XIInstrument.cpp
@@ -329,7 +329,7 @@ static mp_sint32 gusFreqToFT2Note(mp_dword freq)
 	for (mp_uint32 no = 0; no < sizeof(scale_table)/sizeof(mp_dword)-1; no++)
 	{
 		if (scale_table[no] <= freq && 
-			scale_table[no+1] >= freq)
+			scale_table[no+1] > freq)
 			return (no-12);
 	}
 	
@@ -458,7 +458,7 @@ mp_sint32 XIInstrument::loadPAT(XMFile& f)
 		//if (i == numsamples - 1)
 		//	hi = 96;
 		
-		for (mp_sint32 j = lo; j < hi; j++)
+		for (mp_sint32 j = lo; j <= hi; j++)
 			if (j >= 0 && j <= 95)
 				if (nbu[j] == 0xFF) nbu[j] = i;
 		

--- a/src/ppui/CheckBoxLabel.cpp
+++ b/src/ppui/CheckBoxLabel.cpp
@@ -1,0 +1,60 @@
+/*
+*  ppui/CheckBoxLabel.h
+*
+*  Copyright 2017 Henri Isojärvi
+*
+*  This file is part of Milkytracker.
+*
+*  Milkytracker is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  Milkytracker is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "CheckBoxLabel.h"
+
+PPCheckBoxLabel::PPCheckBoxLabel(pp_int32 id, PPScreen* parentScreen, EventListenerInterface* eventListener, 
+	const PPPoint& location, 
+	const PPString& text, 
+    PPCheckBox* checkBox, 
+	bool drawShadow, 
+	bool drawUnderlined, 
+	bool autoShrink) :
+	PPStaticText(id, parentScreen, eventListener, location,
+		text,
+		drawShadow,
+		drawUnderlined,
+		autoShrink)
+{
+	this->checkBox = checkBox;
+}
+
+PPCheckBoxLabel::~PPCheckBoxLabel()
+{
+}
+
+// Toggles the associated check box when the label text is clicked
+pp_int32 PPCheckBoxLabel::dispatchEvent(PPEvent * event)
+{
+	if (!eventListener)
+		return -1;
+
+	switch (event->getID())
+	{
+	case eLMouseDown:
+	case eLMouseUp:
+		return checkBox->dispatchEvent(event);
+	default:
+		return -1;
+	}
+}
+

--- a/src/ppui/CheckBoxLabel.h
+++ b/src/ppui/CheckBoxLabel.h
@@ -1,0 +1,52 @@
+/*
+*  ppui/CheckBoxLabel.h
+*
+*  Copyright 2017 Henri Isojärvi
+*
+*  This file is part of Milkytracker.
+*
+*  Milkytracker is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  Milkytracker is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+/////////////////////////////////////////////////////////////////
+//
+//	Check box label control class
+//
+/////////////////////////////////////////////////////////////////
+#ifndef CHECKBOXLABEL__H
+#define CHECKBOXLABEL__H
+
+#include "StaticText.h"
+#include "CheckBox.h"
+
+class PPCheckBoxLabel : public PPStaticText
+{
+private:
+	PPCheckBox* checkBox;
+
+public:
+	PPCheckBoxLabel(pp_int32 id, PPScreen* parentScreen, EventListenerInterface* eventListener,
+		const PPPoint& location,
+		const PPString& text,
+	    PPCheckBox* checkBox,
+		bool drawShadow = false,
+		bool drawUnderlined = false,
+		bool autoShrink = false);
+
+	virtual ~PPCheckBoxLabel();
+
+	virtual pp_int32 dispatchEvent(PPEvent* event);
+};
+#endif

--- a/src/tracker/SectionInstruments.cpp
+++ b/src/tracker/SectionInstruments.cpp
@@ -43,6 +43,7 @@
 #include "PPUIConfig.h"
 #include "Button.h"
 #include "CheckBox.h"
+#include "CheckBoxLabel.h"
 #include "MessageBoxContainer.h"
 #include "TransparentContainer.h"
 #include "ListBox.h"
@@ -662,15 +663,17 @@ void SectionInstruments::init(pp_int32 x, pp_int32 y)
 
 	y4+=18;
 
-	containerEnvelopes->addControl(new PPCheckBox(CHECKBOX_ENVELOPE_ON, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2)));
+	PPCheckBox* checkBox = new PPCheckBox(CHECKBOX_ENVELOPE_ON, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2));
+	containerEnvelopes->addControl(checkBox);
 
-	containerEnvelopes->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 3), "On", true));
+	containerEnvelopes->addControl(new PPCheckBoxLabel(0, NULL, this, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 3), "On", checkBox, true));
 
 	// sustain
-	containerEnvelopes->addControl(new PPCheckBox(CHECKBOX_ENVELOPE_SUSTAIN, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18)));
+	checkBox = new PPCheckBox(CHECKBOX_ENVELOPE_SUSTAIN, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18));
+	containerEnvelopes->addControl(checkBox);
 
-	containerEnvelopes->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 2 + 18+1), "Sustain:", true));
-	
+	containerEnvelopes->addControl(new PPCheckBoxLabel(0, NULL, this, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 2 + 18 + 1), "Sustain:", checkBox, true));
+
 	containerEnvelopes->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18+1 + 12), "Point", true));
 
 	// sustain point field
@@ -687,9 +690,10 @@ void SectionInstruments::init(pp_int32 x, pp_int32 y)
 	containerEnvelopes->addControl(button);
 
 	// loop
-	containerEnvelopes->addControl(new PPCheckBox(CHECKBOX_ENVELOPE_LOOP, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18*2 + 9)));
+	checkBox = new PPCheckBox(CHECKBOX_ENVELOPE_LOOP, screen, this, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18 * 2 + 9));
+	containerEnvelopes->addControl(checkBox);
 
-	containerEnvelopes->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 2 + 18*2 + 10), "Loop:", true));
+	containerEnvelopes->addControl(new PPCheckBoxLabel(0, NULL, this, PPPoint(x + envelopeEditorControl->getSize().width + 4 + 13, y4 + 2 + 18*2 + 10), "Loop:", checkBox, true));
 
 	containerEnvelopes->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x + envelopeEditorControl->getSize().width + 4, y4 + 2 + 18*2 + 10 + 12), "Start", true));
 


### PR DESCRIPTION
This contains fixes to GUS patch loading, related to issue #51 
- When GUS frequency matched exactly one of the FT2 note frequencies, incorrect note was returned
- Sample was not mapped to the highest note of its frequency interval, which in some cases caused notes to default to sample 0.
- If sample 0 had very small low frequency, then all notes up to note 48 were incorrectly mapped to sample 0.