### PR TITLE
Fixes #96 : Map F13 to the INSERT virtual key on OSX.

### DIFF
--- a/src/tracker/cocoa/MTKeyTranslator.mm
+++ b/src/tracker/cocoa/MTKeyTranslator.mm
@@ -132,6 +132,7 @@
 		case kVK_F10:			return VK_F10;
 		case kVK_F11:			return VK_F11;
 		case kVK_F12:			return VK_F12;
+		case kVK_F13:			return VK_INSERT;
 
 		default:				return VK_UNDEFINED;
 	}


### PR DESCRIPTION
This is a quick and simple fix, but not a hack, so there's no reason why it can't be used in the long term as the proper fix for OSX, but see notes below.

Since Mac doesn't have an INSERT key (and Cocoa doesn't have the concept of one, so it can't be simulated either) we need a key on Mac for INSERT. F13 is above the fn key on a full size Mac keyboard (fn is above delete, where Ins is on standard non-Mac keyboards), so seems an obvious choice. However, the compact (laptop and Bluetooth) keyboards don't have an F13, so this is only a partial fix. It is possible to simulate any key on Mac easily enough with an Automator script and a system-preferences keyboard shortcut, so F13 can be simulated in OSX for those without a full-size keyboard.

TODO: Update manual to reflect the key to use for insert on OSX.

Possible Further Enhancements:
Add a preferences pane with different options for mapping to VK_INSERT, so that people without full-size keyboards can select their preferred alternate key or key-combination.
