### PR TITLE
Fix a compiler error with with libc++ 3.8.0

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,8 +28,14 @@ set(
     ChangeLog.html
 )
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "BSD")
+    set(BSD TRUE)
+endif()
+
 if(APPLE)
     set(INSTALL_DEST Documentation)
+elseif(BSD)
+    set(INSTALL_DEST share/doc/${PROJECT_NAME_LOWER})
 elseif(WIN32)
     list(APPEND DOCUMENTS readme_rtaudio)
     set(INSTALL_DEST .)

--- a/src/tracker/TrackerStartUp.cpp
+++ b/src/tracker/TrackerStartUp.cpp
@@ -127,7 +127,7 @@ void Tracker::showSplash()
 		screen->paintSplash(LogoBig::rawData, LogoBig::width, LogoBig::height, LogoBig::width*3, 3, (int)shade); 		
 #endif
 		shade+=deltaT * (1.0f/6.25f);
-		deltaT = abs((signed)::PPGetTickCount() - startTime);
+		deltaT = abs((pp_int32)::PPGetTickCount() - startTime);
 		if (!deltaT) deltaT++;
 	}
 #if defined(__EXCLUDE_BIGLOGO__) || defined(__LOWRES__)
@@ -158,7 +158,7 @@ void Tracker::hideSplash()
 		screen->paintSplash(LogoBig::rawData, LogoBig::width, LogoBig::height, LogoBig::width*3, 3, (int)shade); 		
 #endif
 		shade-=deltaT * (1.0f/6.25f);
-		deltaT = abs((signed)::PPGetTickCount() - startTime);
+		deltaT = abs((pp_int32)::PPGetTickCount() - startTime);
 		if (!deltaT) deltaT++;
 	}
 	screen->clear(); 	


### PR DESCRIPTION
```
TrackerStartUp.cpp:129:12: error: call to 'abs' is ambiguous
                deltaT = abs(::PPGetTickCount() - startTime);
                         ^~~
```

This is because PPGetTickCount() returns an unsigned value, and it is therefore ambiguous to which type the expression should be casted before calling abs(). A similar ambiguity exists further down in the cpp file.  Fix these by explicity casting the PPGetTickCount() return value to a signed type.

This bug was originally reported in the [FreeBSD bugtracker](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=208489).