### PR TITLE
Added alternative keybindings for Increase / Decrease Row Insert

### DIFF
--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -717,6 +717,12 @@
 			<tr class="odd">
 				<td><em>1</em></td><td>Enter key-off (OS X only)</td>
 			</tr>
+            <tr class="even">
+				<td><em>Alt-Minus</em></td><td>Increase Add value</td>
+			</tr>
+			<tr class="odd">
+				<td><em>or Alt-Plus</em></td><td>Decrease Add value</td>
+			</tr>
 		</table>
 		<h4>Transpose:</h4>
 		<table>
@@ -887,10 +893,10 @@
 			<tr class="odd">
 				<td><em>Ctrl-F12</em></td><td>Increase current order pattern number</td>
 			<tr class="even">
-				<td><em>Key below ESC</em></td><td>Increase Add value</td>
+				<td><em>Key below ESC (ANSI: Alt-Minus)*</em></td><td>Increase Add value</td>
 			</tr>
 			<tr class="odd">
-				<td><em>Shift-key below ESC</em></td><td>Decrease Add value</td>
+				<td><em>Shift-key below ESC (ANSI: Alt-Plus)*</em></td><td>Decrease Add value</td>
 			</tr>
 			<tr class="even">
 				<td><em>Ctrl-F</em></td><td>Toggle song follow</td>
@@ -917,6 +923,9 @@
 				<td><em>Esc</em></td><td>Exit program</td>
 			</tr>
 		</table>
+		<p>
+			* <em>Please note</em> in this table, "Key under esc" refers to the tilde / tick key, section symbol / plusminus key or the ring accent / circumflex key depending on your ISO keyboard, but does not exist on ANSI layouts. See: <a href="https://github.com/milkytracker/MilkyTracker/issues/120#issuecomment-327614068">this issue</a> for details
+		</p>
 		<h4>Pattern editor:</h4>
 		<table>
 			<tr class="even">

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -73,6 +73,11 @@ void PatternEditorControl::initKeyBindings()
 	// Scancode bindings
 	scanCodeBindingsMilkyTracker = new PPKeyBindings<TPatternEditorKeyBindingHandler>;
 
+	// Alternate binding for eventKeyDownBinding_SC_IncreaseRowInsertAdd
+	// for modern ANSI keyboards without section symbol key
+    scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_DecreaseRowInsertAdd);
+	scanCodeBindingsMilkyTracker->addBinding(SC_TICK, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_IncreaseRowInsertAdd);
+
 	scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsDecSelection);
 	scanCodeBindingsMilkyTracker->addBinding(SC_TICK, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsIncSelection);
 	scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierSHIFT|KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsDecTrack);
@@ -178,6 +183,11 @@ void PatternEditorControl::initKeyBindings()
 	
 	scanCodeBindingsFastTracker->addBinding(SC_WTF, 0, &PatternEditorControl::eventKeyDownBinding_SC_IncreaseRowInsertAdd);
 	scanCodeBindingsFastTracker->addBinding(SC_WTF, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_SC_DecreaseRowInsertAdd);
+
+	// Alternate binding for eventKeyDownBinding_SC_IncreaseRowInsertAdd
+	// for modern ANSI keyboards without section symbol key
+	scanCodeBindingsFastTracker->addBinding(SC_SS, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_DecreaseRowInsertAdd);
+	scanCodeBindingsFastTracker->addBinding(SC_TICK, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_IncreaseRowInsertAdd);
 
 	scanCodeBindingsFastTracker->addBinding(SC_SS, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsDecSelection);
 	scanCodeBindingsFastTracker->addBinding(SC_TICK, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsIncSelection);

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -75,7 +75,7 @@ void PatternEditorControl::initKeyBindings()
 
 	// Alternate binding for eventKeyDownBinding_SC_IncreaseRowInsertAdd
 	// for modern ANSI keyboards without section symbol key
-    scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_DecreaseRowInsertAdd);
+	scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_DecreaseRowInsertAdd);
 	scanCodeBindingsMilkyTracker->addBinding(SC_TICK, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_SC_IncreaseRowInsertAdd);
 
 	scanCodeBindingsMilkyTracker->addBinding(SC_SS, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_InsDecSelection);


### PR DESCRIPTION
Alternate keybindings are for modern ANSI keyboards without Section Symbol key.
See Issue #120