### PR TITLE
Fix #124: Add gitignore folder for generated build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# The build output folder
+build/
+
+# Resources generated with docerator on OSX
+resources/pictures/docicons/osx/MilkyTracker-*.icns
+resources/pictures/docicons/osx/docerator/


### PR DESCRIPTION
Tested by building, running `git status` to see the files,
adding the `.gitignore` file, verifying that `git status`
shows no changes.