### PR TITLE
Add: better plaform compatibility, default to OpenGL ES2 renderer

### DIFF
--- a/src/ppui/sdl/DisplayDeviceFB_SDL.cpp
+++ b/src/ppui/sdl/DisplayDeviceFB_SDL.cpp
@@ -57,7 +57,7 @@ PPDisplayDeviceFB::PPDisplayDeviceFB(pp_int32 width,
 	}
 	
 	// Create renderer for the window
-	theRenderer = SDL_CreateRenderer(theWindow, -1, 0);
+	theRenderer = SDL_CreateRenderer(theWindow, drv_index, 0);
 	if (theRenderer == NULL)
 	{
 		fprintf(stderr, "SDL: SDL_CreateRenderer failed: %s\n", SDL_GetError());

--- a/src/ppui/sdl/DisplayDevice_SDL.h
+++ b/src/ppui/sdl/DisplayDevice_SDL.h
@@ -32,6 +32,9 @@
 #include "DisplayDeviceBase.h"
 
 #include <SDL.h>
+#include <SDL_opengl.h>
+
+typedef const GLubyte *(APIENTRYP PFNGLGETSTRINGPROC) (GLenum name);
 
 // Forwards
 class PPGraphicsAbstract;
@@ -51,6 +54,7 @@ protected:
 	pp_int32 realWidth, realHeight;
 	SDL_Window* theWindow;
 	Orientations orientation;
+	int drv_index;
 	
 	SDL_Window* CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags);
 


### PR DESCRIPTION
## Description
Try to init SDL2 to always default to OpenGL ES2, as this is supported by most Platforms i.e (MacOS, Windows, Android, Linux, Linux on Single Board Computers like RPi or ODROID

## Motivation and Context
Get faster drawings and better Platform compatibility, as OpenGL ES2 is a subset of OpenGL, nowadays all GPU driver support OpenGL ES2 too but not all OpenGL ES2 capable device support OpenGL ( i.e SBC's ), if the GPU driver is somewhat old than it will fallback (create renderer with -1 driver index) to the first supported renderer which is probably OpenGL 1.0 or 1.1, in worst case it is a software renderer but this is only on very old hardware the case.

## How Has This Been Tested?
SBC's like ODROID XU4 and N1
but it should work on: all Windows, MacOS, Android, Linux and Unix like OS if they too build a SDL2 version of MilkyTracker

## Screenshot:

![milkytracker](https://user-images.githubusercontent.com/1681560/38200984-c938ae2a-3696-11e8-8e83-36f080e352f1.png)
