### PR TITLE
SDL-1.2 backwards compatibility proposal

### DIFF
--- a/src/milkyplay/drivers/sdl/AudioDriver_SDL.cpp
+++ b/src/milkyplay/drivers/sdl/AudioDriver_SDL.cpp
@@ -99,8 +99,11 @@ mp_sint32 AudioDriver_SDL::initDevice(mp_sint32 bufferSizeInWords, mp_uint32 mix
 		return MP_DEVICE_ERROR;
 	}
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	printf("SDL: Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
-
+#else
+	printf("SDL: Using audio driver: %s\n", SDL_AudioDriverName(name, 32));
+#endif
 	if(wanted.format != obtained.format)
 	{
 		fprintf(stderr, "SDL: Audio driver doesn't support 16-bit signed samples!\n");

--- a/src/ppui/osinterface/sdl/SDL_ModalLoop.cpp
+++ b/src/ppui/osinterface/sdl/SDL_ModalLoop.cpp
@@ -102,9 +102,15 @@ PPModalDialog::ReturnCodes SDL_runModalLoop(PPScreen* screen, PPDialogBase* dial
 				// ignore old mouse motion events in the event queue
 				SDL_Event new_event;
 				
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 				if (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0)
 				{
 					while (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0);
+#else
+				if (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0)
+				{
+					while (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0);
+#endif
 					processSDLEvents(new_event);
 				} 
 				else 

--- a/src/ppui/sdl/DisplayDeviceFB_SDL.h
+++ b/src/ppui/sdl/DisplayDeviceFB_SDL.h
@@ -31,6 +31,10 @@
 #ifndef __DISPLAYDEVICEFB_H__
 #define __DISPLAYDEVICEFB_H__
 
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 2
+#endif
+
 #include "DisplayDevice_SDL.h"
 
 class PPDisplayDeviceFB : public PPDisplayDevice
@@ -44,7 +48,11 @@ private:
 	void swap(const PPRect& r);
 
 public:
-	PPDisplayDeviceFB(pp_int32 width,
+	PPDisplayDeviceFB(
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+					  SDL_Surface*& screen, 
+#endif
+					  pp_int32 width, 
 					  pp_int32 height, 
 					  pp_int32 scaleFactor,
 					  pp_int32 bpp, 
@@ -55,17 +63,21 @@ public:
 	virtual ~PPDisplayDeviceFB();
 
 	virtual bool supportsScaling() const { return true; }
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	virtual void setSize(const PPSize& size);
+#endif
 
 	virtual PPGraphicsAbstract* open();
 	virtual void close();
 
 	void update();
 	void update(const PPRect& r);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 protected:
 	SDL_Surface* theSurface;
 	SDL_Texture* theTexture;
 	SDL_Renderer* theRenderer;
+#endif
 };
 
 #endif

--- a/src/ppui/sdl/DisplayDeviceOGL_SDL.h
+++ b/src/ppui/sdl/DisplayDeviceOGL_SDL.h
@@ -28,12 +28,20 @@
 #ifndef __DISPLAYDEVICEOGL_H__
 #define __DISPLAYDEVICEOGL_H__
 
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 2
+#endif
+
 #include "DisplayDevice_SDL.h"
 
 class PPDisplayDeviceOGL : public PPDisplayDevice
 {
 public:
-	PPDisplayDeviceOGL(pp_int32 width,
+	PPDisplayDeviceOGL(
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+					   SDL_Surface*& screen, 
+#endif
+					   pp_int32 width, 
 					   pp_int32 height, 
 					   pp_int32 scaleFactor,
 					   pp_int32 bpp, 
@@ -48,8 +56,10 @@ public:
 
 	void update();
 	void update(const PPRect& r);
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 protected:
 	SDL_GLContext glContext;
+#endif
 };
 
 #endif

--- a/src/ppui/sdl/DisplayDevice_SDL.cpp
+++ b/src/ppui/sdl/DisplayDevice_SDL.cpp
@@ -23,6 +23,7 @@
 #include "DisplayDevice_SDL.h"
 #include "Graphics.h"
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags)
 {
 	char rendername[256] = { 0 };
@@ -88,8 +89,41 @@ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bp
 
 	return theWindow;
 }
+#else
+SDL_Surface* PPDisplayDevice::CreateScreen(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags)
+{
+	SDL_Surface *screen;
+	
+	/* Set the video mode */
+	screen = SDL_SetVideoMode(w, h, bpp, flags);
+	if (screen == NULL) 
+	{
+		fprintf(stderr, "Couldn't set display mode: %s\n", SDL_GetError());
+		fprintf(stderr, "Retrying with default size...");
 
-PPDisplayDevice::PPDisplayDevice(pp_int32 width,
+		w = getDefaultWidth();
+		h = getDefaultHeight();
+		
+		screen = SDL_SetVideoMode(w, h, bpp, flags);
+		
+		if (screen == NULL) 
+		{
+			fprintf(stderr, "Couldn't set display mode: %s\n", SDL_GetError());
+			fprintf(stderr, "Giving up.");
+			
+			return NULL;
+		}
+	}
+
+	return screen;
+}
+#endif
+
+PPDisplayDevice::PPDisplayDevice(
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+								 SDL_Surface*& screen, 
+#endif
+								 pp_int32 width, 
 								 pp_int32 height, 
 								 pp_int32 scaleFactor,
 								 pp_int32 bpp,
@@ -103,8 +137,9 @@ PPDisplayDevice::PPDisplayDevice(pp_int32 width,
 
 	bFullScreen = fullScreen;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	drv_index = -1;
-
+#endif
 	initMousePointers();
 }
 
@@ -198,36 +233,52 @@ void PPDisplayDevice::transformInverse(PPRect& r)
 
 void PPDisplayDevice::setTitle(const PPSystemString& title)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 	SDL_SetWindowTitle(theWindow, title);
+#else
+	SDL_WM_SetCaption(title, "MilkyTracker");
+#endif
 }
+
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+void PPDisplayDevice::setSize(const PPSize& size)	
+{	
+	theSurface = SDL_SetVideoMode(size.width, size.height, theSurface->format->BitsPerPixel, theSurface->flags);	
+}
+#endif
 
 bool PPDisplayDevice::goFullScreen(bool b)
 {
 	// In X11, this will make MilkyTracker go fullscreen at the selected
 	// resolution.
-
-	if (!b && (SDL_SetWindowFullscreen(theWindow, SDL_FALSE) == 0))
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (SDL_SetWindowFullscreen(theWindow, (!b)?SDL_FALSE:SDL_WINDOW_FULLSCREEN_DESKTOP) == 0)
 	{
-		bFullScreen = false;
+		bFullScreen = b;
 		return true;
 	}
-
-	else if (b && (SDL_SetWindowFullscreen(theWindow, SDL_WINDOW_FULLSCREEN_DESKTOP) == 0))
+#else
+	SDL_Surface* screen = SDL_GetVideoSurface();
+	if (SDL_WM_ToggleFullScreen(screen)) 
 	{
-		bFullScreen = true;
+		bFullScreen = !bFullScreen;
 		return true;
 	}
+#endif
 	
 	return false;
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 SDL_Window* PPDisplayDevice::getWindow() {
 	return theWindow;
 }
+#endif
 
 // Defined in main.cpp
 void exitSDLEventLoop(bool serializedEventInvoked = true);
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 PPSize PPDisplayDevice::getDisplayResolution() const {
 	// Find the monitor MilkyTracker is being displayed on
 	int currentDisplay = SDL_GetWindowDisplayIndex(theWindow);
@@ -242,6 +293,7 @@ PPSize PPDisplayDevice::getDisplayResolution() const {
 	// Return the desktop size
 	return PPSize(displayMode.w, displayMode.h);
 }
+#endif
 
 void PPDisplayDevice::shutDown()
 {
@@ -257,12 +309,20 @@ void PPDisplayDevice::setMouseCursor(MouseCursorTypes type)
 		case MouseCursorTypeStandard:
 			SDL_SetCursor(cursorStandard);
 			break;
-			
+#if SDL_VERSION_ATLEAST(2, 0, 0)			
 		case MouseCursorTypeResizeLeft:
 		case MouseCursorTypeResizeRight:
 			SDL_SetCursor(cursorResizeHoriz);
 			break;
-	
+#else
+		case MouseCursorTypeResizeLeft:
+			SDL_SetCursor(cursorResizeLeft);
+			break;
+
+		case MouseCursorTypeResizeRight:
+			SDL_SetCursor(cursorResizeRight);
+			break;
+#endif	
 		case MouseCursorTypeHand:
 			SDL_SetCursor(cursorHand);
 			break;
@@ -278,6 +338,7 @@ void PPDisplayDevice::signalWaitState(bool b, const PPColor& color)
 	setMouseCursor(b ? MouseCursorTypeWait : MouseCursorTypeStandard);
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 void PPDisplayDevice::initMousePointers()
 {
 	cursorStandard = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
@@ -285,3 +346,27 @@ void PPDisplayDevice::initMousePointers()
 	cursorEggtimer = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_WAIT);
 	cursorHand = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
 }
+#else
+// Mouse pointer data
+Uint8 PPDisplayDevice::resizeLeft_data[] = { 0, 0, 96, 0, 97, 128, 99, 0, 102, 0, 108, 0, 120, 0, 127, 254, 120, 0, 124, 0, 102, 0, 99, 0, 97, 128, 96, 0, 0, 0, 0, 0 };
+Uint8 PPDisplayDevice::resizeLeft_mask[] = { 240, 0, 241, 128, 243, 192, 247, 128, 255, 0, 254, 0, 255, 255, 255, 255, 255, 255, 254, 0, 255, 0, 247, 128, 243, 192, 241, 128, 240, 0, 0, 0 };
+Uint8 PPDisplayDevice::resizeRight_data[] = { 0, 0, 0, 6, 1, 134, 0, 198, 0, 102, 0, 54, 0, 30, 127, 254, 0, 30, 0, 62, 0, 102, 0, 198, 1, 134, 0, 6, 0, 0, 0, 0 };
+Uint8 PPDisplayDevice::resizeRight_mask[] = { 0, 15, 1, 143, 3, 207, 1, 239, 0, 255, 0, 127, 255, 255, 255, 255, 255, 255, 0, 127, 0, 255, 1, 239, 3, 207, 1, 143, 0, 15, 0, 0, };
+Uint8 PPDisplayDevice::eggtimer_data[] = { 0, 0, 127, 192, 32, 128, 32, 128, 17, 0, 17, 0, 10, 0, 4, 0, 4, 0, 10, 0, 17, 0, 17, 0, 32, 128, 32, 128, 127, 192, 0, 0 };
+Uint8 PPDisplayDevice::eggtimer_mask[] = { 255, 224, 255, 224, 127, 192, 127, 192, 63, 128, 63, 128, 31, 0, 14, 0, 14, 0, 31, 0, 63, 128, 63, 128, 127, 192, 127, 192, 255, 224, 255, 224 };
+Uint8 PPDisplayDevice::hand_data[] = {54, 192, 91, 64, 146, 64, 146, 112, 146, 104, 146, 104, 128, 40, 128, 40, 128, 8, 128, 8, 128, 16, 64, 16, 64, 32, 32, 32, 31, 192, 0, 0, };
+Uint8 PPDisplayDevice::hand_mask[] = {54, 192, 127, 192, 255, 192, 255, 240, 255, 248, 255, 248, 255, 248, 255, 248, 255, 248, 255, 248, 255, 240, 127, 240, 127, 224, 63, 224, 31, 192, 0, 0, };
+
+void PPDisplayDevice::initMousePointers()
+{
+	cursorResizeLeft = SDL_CreateCursor(resizeLeft_data, resizeLeft_mask, 16, 16, 2, 7);
+	cursorResizeRight = SDL_CreateCursor(resizeRight_data, resizeRight_mask, 16, 16, 13, 7);
+	cursorEggtimer = SDL_CreateCursor(eggtimer_data, eggtimer_mask, 16, 16, 5, 7);
+	cursorHand = SDL_CreateCursor(hand_data, hand_mask, 16, 16, 5, 5);
+
+	// The current cursor is used as the standard cursor;
+	// This might cause problems if the system if displaying some other cursor at
+	// the time, or it might not. It depends.
+	cursorStandard = SDL_GetCursor();
+}
+#endif

--- a/src/ppui/sdl/DisplayDevice_SDL.h
+++ b/src/ppui/sdl/DisplayDevice_SDL.h
@@ -32,9 +32,11 @@
 #include "DisplayDeviceBase.h"
 
 #include <SDL.h>
+#if SDL_VERSION_ATLEAST(2, 0, 0)
 #include <SDL_opengl.h>
 
 typedef const GLubyte *(APIENTRYP PFNGLGETSTRINGPROC) (GLenum name);
+#endif
 
 // Forwards
 class PPGraphicsAbstract;
@@ -52,21 +54,36 @@ public:
 
 protected:
 	pp_int32 realWidth, realHeight;
-	SDL_Window* theWindow;
 	Orientations orientation;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_Window* theWindow;
 	int drv_index;
 	
 	SDL_Window* CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags);
+	SDL_Cursor *cursorStandard, *cursorResizeHoriz, *cursorEggtimer, *cursorHand;
+#else
+	SDL_Surface* theSurface;
+	SDL_Surface* CreateScreen(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags);
+	SDL_Cursor *cursorStandard, *cursorResizeLeft, *cursorResizeRight, *cursorEggtimer, *cursorHand;
+	static Uint8 resizeLeft_data[], resizeLeft_mask[];
+	static Uint8 resizeRight_data[], resizeRight_mask[];
+	static Uint8 eggtimer_data[], eggtimer_mask[];
+	static Uint8 hand_data[], hand_mask[];
+#endif
 
 	// used for rotating coordinates etc.
 	void adjust(pp_int32& x, pp_int32& y);
 
 	// Mouse pointers
-	SDL_Cursor *cursorStandard, *cursorResizeHoriz, *cursorEggtimer, *cursorHand;
+	
 	void initMousePointers();
 
 public:
-	PPDisplayDevice(pp_int32 width,
+	PPDisplayDevice(
+#if !SDL_VERSION_ATLEAST(2, 0, 0)
+					SDL_Surface*& screen,
+#endif
+					pp_int32 width,
 					pp_int32 height, 
 					pp_int32 scaleFactor,
 					pp_int32 bpp, 
@@ -74,19 +91,24 @@ public:
 					Orientations theOrientation = ORIENTATION_NORMAL);
 				  
 	virtual ~PPDisplayDevice();
-	
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	SDL_Window* getWindow();
+	virtual PPSize getDisplayResolution() const;
+#else
+	virtual void setSize(const PPSize& size);
+#endif
 	void transform(pp_int32& x, pp_int32& y);
 	void transformInverse(pp_int32& x, pp_int32& y);
 	void transformInverse(PPRect& r);
 
 	Orientations getOrientation() { return orientation; }
-	
-	SDL_Window* getWindow();
+
+
 
 	// ----------------------------- ex. PPWindow ----------------------------
 	virtual void setTitle(const PPSystemString& title);	
 	virtual bool goFullScreen(bool b);
-	virtual PPSize getDisplayResolution() const;
+
 	virtual void shutDown();
 	virtual void signalWaitState(bool b, const PPColor& color);
 	virtual void setMouseCursor(MouseCursorTypes type);

--- a/src/tracker/sdl-1.2/SDL_KeyTranslation.cpp
+++ b/src/tracker/sdl-1.2/SDL_KeyTranslation.cpp
@@ -1,0 +1,481 @@
+/*
+ *  tracker/sdl/SDL_KeyTranslation.cpp
+ *
+ *  Copyright 2009 Peter Barth, Christopher O'Neill
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  KeyTranslation.cpp
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on 19.11.05.
+ *
+ *  14/8/06 - Christopher O'Neill
+ *    PC specific code added to toSC - allows none qwerty layouts to work
+ *    Small fix in toSC
+ *    Various keys added to toVK - rewritten to use array instead of select
+ */
+#ifdef __APPLE__
+#define NOT_PC_KB
+#endif
+
+#include "SDL_KeyTranslation.h"
+
+bool isX11 = false;
+bool stdKb = true;
+
+static const pp_uint16 sdl_keysym_to_vk[] = {
+	SDLK_CARET, 0xC0,
+	SDLK_WORLD_0, 0xBB,
+	SDLK_WORLD_1, 0xBD,
+	SDLK_PLUS, 0xDD,
+	SDLK_WORLD_2, 0xDB,
+	SDLK_RETURN, VK_RETURN,
+	SDLK_WORLD_3, 0xDE,
+	SDLK_WORLD_4, 0xBA,
+	SDLK_HASH, 0xDC,
+	SDLK_COMMA, 188,
+	SDLK_PERIOD, 0xBF,
+	SDLK_MINUS, 190,
+	SDLK_TAB, VK_TAB,
+	SDLK_SPACE, VK_SPACE,
+	SDLK_LESS, 0xE2,
+	SDLK_BACKSPACE, VK_BACK,
+	SDLK_ESCAPE, VK_ESCAPE,
+	SDLK_F1, VK_F1,
+	SDLK_F2, VK_F2,
+	SDLK_F3, VK_F3,
+	SDLK_F4, VK_F4,
+	SDLK_F5, VK_F5,
+	SDLK_F6, VK_F6,
+	SDLK_F7, VK_F7,
+	SDLK_F8, VK_F8,
+	SDLK_F9, VK_F9,
+	SDLK_F10, VK_F10,
+	SDLK_F11, VK_F11,
+	SDLK_F12, VK_F12,
+	SDLK_INSERT, VK_INSERT,
+	SDLK_HOME, VK_HOME,
+	SDLK_PAGEUP, VK_PRIOR,
+	SDLK_DELETE, VK_DELETE,
+	SDLK_END, VK_END,
+	SDLK_PAGEDOWN, VK_NEXT,
+	SDLK_LEFT, VK_LEFT,
+	SDLK_RIGHT, VK_RIGHT,
+	SDLK_DOWN, VK_DOWN,
+	SDLK_UP, VK_UP,
+	SDLK_LALT, VK_ALT,
+	SDLK_LSHIFT, VK_SHIFT,
+	SDLK_RSHIFT, VK_SHIFT,
+	SDLK_LCTRL, VK_LCONTROL,
+	SDLK_RCTRL, VK_RCONTROL,
+	SDLK_MODE, VK_RMENU,
+
+	// Numpad
+	SDLK_KP0, VK_NUMPAD0,
+	SDLK_KP1, VK_NUMPAD1,
+	SDLK_KP2, VK_NUMPAD2,
+	SDLK_KP3, VK_NUMPAD3,
+	SDLK_KP4, VK_NUMPAD4,
+	SDLK_KP5, VK_NUMPAD5,
+	SDLK_KP6, VK_NUMPAD6,
+	SDLK_KP7, VK_NUMPAD7,
+	SDLK_KP8, VK_NUMPAD8,
+	SDLK_KP9, VK_NUMPAD9,
+	SDLK_KP_PERIOD, VK_DECIMAL,
+	SDLK_KP_DIVIDE, VK_DIVIDE,
+	SDLK_KP_MULTIPLY, VK_MULTIPLY,
+	SDLK_KP_MINUS, VK_SUBTRACT,
+	SDLK_KP_PLUS, VK_ADD,
+	SDLK_KP_ENTER, VK_SEPARATOR
+};
+
+
+pp_uint16 toVK(const SDL_keysym& keysym)
+{
+	if (keysym.sym >= SDLK_a && keysym.sym <= SDLK_z)
+		return (pp_uint16)keysym.sym-32;
+
+	// azerty keyboards won't work with this, they get fixed in SDL_Main.cpp
+	if (keysym.sym >= SDLK_0 && keysym.sym <= SDLK_9)
+		return (pp_uint16)keysym.sym;
+
+	for(int i=0; i < sizeof(sdl_keysym_to_vk)/2; i+=2)
+		if(sdl_keysym_to_vk[i] == keysym.sym)
+			return sdl_keysym_to_vk[i+1];
+	
+	return 0;
+}
+
+static const pp_uint32 sdl_keycode_to_pc_keycode[] = {
+     0x00, /* 0 SDLK_UNKNOWN */
+     0x00, /* 1 */
+     0x00, /* 2 */
+     0x00, /* 3 */
+     0x00, /* 4 */
+     0x00, /* 5 */
+     0x00, /* 6 */
+     0x00, /* 7 */
+     0x0e, /* 8 SDLK_BACKSPACE */
+     0x0f, /* 9 SDLK_TAB */
+     0x00, /* 10 */
+     0x00, /* 11 */
+     0x00, /* 12 SDLK_CLEAR */
+     0x1c, /* 13 SDLK_RETURN */
+     0x00, /* 14 */
+     0x00, /* 15 */
+     0x00, /* 16 */
+     0x00, /* 17 */
+     0x00, /* 18 */
+     0x451de1, /* 19 SDLK_PAUSE */
+     0x00, /* 20 */
+     0x00, /* 21 */
+     0x00, /* 22 */
+     0x00, /* 23 */
+     0x00, /* 24 */
+     0x00, /* 25 */
+     0x00, /* 26 */
+     0x01, /* 27 SDLK_ESCAPE */
+     0x00, /* 28 */
+     0x00, /* 29 */
+     0x00, /* 30 */
+     0x00, /* 31 */
+     0x39, /* 32 SDLK_SPACE */
+     0x02, /* 33 SDLK_EXCLAIM */
+     0x28, /* 34 SDLK_QUOTEDBL */
+     0x04, /* 35 SDLK_HASH */
+     0x05, /* 36 SDLK_DOLLAR */
+     0x00, /* 37 */
+     0x08, /* 38 SDLK_AMPERSAND */
+     0x28, /* 39 SDLK_QUOTE */
+     0x0a, /* 40 SDLK_LEFTPAREN */
+     0x0b, /* 41 SDLK_RIGHTPAREN */
+     0x09, /* 42 SDLK_ASTERISK */
+     0x0d, /* 43 SDLK_PLUS */
+     0x33, /* 44 SDLK_COMMA */
+     0x0c, /* 45 SDLK_MINUS */
+     0x34, /* 46 SDLK_PERIOD */
+     0x35, /* 47 SDLK_SLASH */
+     0x0b, /* 48 SDLK_0 */
+     0x02, /* 49 SDLK_1 */
+     0x03, /* 50 SDLK_2 */
+     0x04, /* 51 SDLK_3 */
+     0x05, /* 52 SDLK_4 */
+     0x06, /* 53 SDLK_5 */
+     0x07, /* 54 SDLK_6 */
+     0x08, /* 55 SDLK_7 */
+     0x09, /* 56 SDLK_8 */
+     0x0a, /* 57 SDLK_9 */
+     0x27, /* 58 SDLK_COLON */
+     0x27, /* 59 SDLK_SEMICOLON */
+     0x33, /* 60 SDLK_LESS */
+     0x0d, /* 61 SDLK_EQUALS */
+     0x34, /* 62 SDLK_GREATER */
+     0x35, /* 63 SDLK_QUESTION */
+     0x03, /* 64 SDLK_AT */
+     0x00, /* 65 */
+     0x00, /* 66 */
+     0x00, /* 67 */
+     0x00, /* 68 */
+     0x00, /* 69 */
+     0x00, /* 70 */
+     0x00, /* 71 */
+     0x00, /* 72 */
+     0x00, /* 73 */
+     0x00, /* 74 */
+     0x00, /* 75 */
+     0x00, /* 76 */
+     0x00, /* 77 */
+     0x00, /* 78 */
+     0x00, /* 79 */
+     0x00, /* 80 */
+     0x00, /* 81 */
+     0x00, /* 82 */
+     0x00, /* 83 */
+     0x00, /* 84 */
+     0x00, /* 85 */
+     0x00, /* 86 */
+     0x00, /* 87 */
+     0x00, /* 88 */
+     0x00, /* 89 */
+     0x00, /* 90 */
+     0x1a, /* 91 SDLK_LEFTBRACKET */
+     0x2b, /* 92 SDLK_BACKSLASH */
+     0x1b, /* 93 SDLK_RIGHTBRACKET */
+     0x07, /* 94 SDLK_CARET */
+     0x0c, /* 95 SDLK_UNDERSCORE */
+     0x29, /* 96 SDLK_BACKQUOTE */
+     0x1e, /* 97 SDLK_a */
+     0x30, /* 98 SDLK_b */
+     0x2e, /* 99 SDLK_c */
+     0x20, /* 100 SDLK_d */
+     0x12, /* 101 SDLK_e */
+     0x21, /* 102 SDLK_f */
+     0x22, /* 103 SDLK_g */
+     0x23, /* 104 SDLK_h */
+     0x17, /* 105 SDLK_i */
+     0x24, /* 106 SDLK_j */
+     0x25, /* 107 SDLK_k */
+     0x26, /* 108 SDLK_l */
+     0x32, /* 109 SDLK_m */
+     0x31, /* 110 SDLK_n */
+     0x18, /* 111 SDLK_o */
+     0x19, /* 112 SDLK_p */
+     0x10, /* 113 SDLK_q */
+     0x13, /* 114 SDLK_r */
+     0x1f, /* 115 SDLK_s */
+     0x14, /* 116 SDLK_t */
+     0x16, /* 117 SDLK_u */
+     0x2f, /* 118 SDLK_v */
+     0x11, /* 119 SDLK_w */
+     0x2d, /* 120 SDLK_x */
+     0x15, /* 121 SDLK_y */
+     0x2c, /* 122 SDLK_z */
+     0x00, /* 123 */
+     0x00, /* 124 */
+     0x00, /* 125 */
+     0x00, /* 126 */
+     0x00, /* 127 SDLK_DELETE */
+     0x00, /* 128 */
+     0x00, /* 129 */
+     0x00, /* 130 */
+     0x00, /* 131 */
+     0x00, /* 132 */
+     0x00, /* 133 */
+     0x00, /* 134 */
+     0x00, /* 135 */
+     0x00, /* 136 */
+     0x00, /* 137 */
+     0x00, /* 138 */
+     0x00, /* 139 */
+     0x00, /* 140 */
+     0x00, /* 141 */
+     0x00, /* 142 */
+     0x00, /* 143 */
+     0x00, /* 144 */
+     0x00, /* 145 */
+     0x00, /* 146 */
+     0x00, /* 147 */
+     0x00, /* 148 */
+     0x00, /* 149 */
+     0x00, /* 150 */
+     0x00, /* 151 */
+     0x00, /* 152 */
+     0x00, /* 153 */
+     0x00, /* 154 */
+     0x00, /* 155 */
+     0x00, /* 156 */
+     0x00, /* 157 */
+     0x00, /* 158 */
+     0x00, /* 159 */
+     0x00, /* 160 SDLK_WORLD_0 */
+     0x00, /* 161 SDLK_WORLD_1 */
+     0x00, /* 162 SDLK_WORLD_2 */
+     0x00, /* 163 SDLK_WORLD_3 */
+     0x00, /* 164 SDLK_WORLD_4 */
+     0x00, /* 165 SDLK_WORLD_5 */
+     0x00, /* 166 SDLK_WORLD_6 */
+     0x00, /* 167 SDLK_WORLD_7 */
+     0x00, /* 168 SDLK_WORLD_8 */
+     0x00, /* 169 SDLK_WORLD_9 */
+     0x00, /* 170 SDLK_WORLD_10 */
+     0x00, /* 171 SDLK_WORLD_11 */
+     0x00, /* 172 SDLK_WORLD_12 */
+     0x00, /* 173 SDLK_WORLD_13 */
+     0x00, /* 174 SDLK_WORLD_14 */
+     0x00, /* 175 SDLK_WORLD_15 */
+     0x00, /* 176 SDLK_WORLD_16 */
+     0x00, /* 177 SDLK_WORLD_17 */
+     0x00, /* 178 SDLK_WORLD_18 */
+     0x00, /* 179 SDLK_WORLD_19 */
+     0x00, /* 180 SDLK_WORLD_20 */
+     0x00, /* 181 SDLK_WORLD_21 */
+     0x00, /* 182 SDLK_WORLD_22 */
+     0x00, /* 183 SDLK_WORLD_23 */
+     0x00, /* 184 SDLK_WORLD_24 */
+     0x00, /* 185 SDLK_WORLD_25 */
+     0x00, /* 186 SDLK_WORLD_26 */
+     0x00, /* 187 SDLK_WORLD_27 */
+     0x00, /* 188 SDLK_WORLD_28 */
+     0x00, /* 189 SDLK_WORLD_29 */
+     0x00, /* 190 SDLK_WORLD_30 */
+     0x00, /* 191 SDLK_WORLD_31 */
+     0x00, /* 192 SDLK_WORLD_32 */
+     0x00, /* 193 SDLK_WORLD_33 */
+     0x00, /* 194 SDLK_WORLD_34 */
+     0x00, /* 195 SDLK_WORLD_35 */
+     0x00, /* 196 SDLK_WORLD_36 */
+     0x00, /* 197 SDLK_WORLD_37 */
+     0x00, /* 198 SDLK_WORLD_38 */
+     0x00, /* 199 SDLK_WORLD_39 */
+     0x00, /* 200 SDLK_WORLD_40 */
+     0x00, /* 201 SDLK_WORLD_41 */
+     0x00, /* 202 SDLK_WORLD_42 */
+     0x00, /* 203 SDLK_WORLD_43 */
+     0x00, /* 204 SDLK_WORLD_44 */
+     0x00, /* 205 SDLK_WORLD_45 */
+     0x00, /* 206 SDLK_WORLD_46 */
+     0x00, /* 207 SDLK_WORLD_47 */
+     0x00, /* 208 SDLK_WORLD_48 */
+     0x00, /* 209 SDLK_WORLD_49 */
+     0x00, /* 210 SDLK_WORLD_50 */
+     0x00, /* 211 SDLK_WORLD_51 */
+     0x00, /* 212 SDLK_WORLD_52 */
+     0x00, /* 213 SDLK_WORLD_53 */
+     0x00, /* 214 SDLK_WORLD_54 */
+     0x00, /* 215 SDLK_WORLD_55 */
+     0x00, /* 216 SDLK_WORLD_56 */
+     0x00, /* 217 SDLK_WORLD_57 */
+     0x00, /* 218 SDLK_WORLD_58 */
+     0x00, /* 219 SDLK_WORLD_59 */
+     0x00, /* 220 SDLK_WORLD_60 */
+     0x00, /* 221 SDLK_WORLD_61 */
+     0x00, /* 222 SDLK_WORLD_62 */
+     0x00, /* 223 SDLK_WORLD_63 */
+     0x00, /* 224 SDLK_WORLD_64 */
+     0x00, /* 225 SDLK_WORLD_65 */
+     0x00, /* 226 SDLK_WORLD_66 */
+     0x00, /* 227 SDLK_WORLD_67 */
+     0x00, /* 228 SDLK_WORLD_68 */
+     0x00, /* 229 SDLK_WORLD_69 */
+     0x00, /* 230 SDLK_WORLD_70 */
+     0x00, /* 231 SDLK_WORLD_71 */
+     0x00, /* 232 SDLK_WORLD_72 */
+     0x00, /* 233 SDLK_WORLD_73 */
+     0x00, /* 234 SDLK_WORLD_74 */
+     0x00, /* 235 SDLK_WORLD_75 */
+     0x00, /* 236 SDLK_WORLD_76 */
+     0x00, /* 237 SDLK_WORLD_77 */
+     0x00, /* 238 SDLK_WORLD_78 */
+     0x00, /* 239 SDLK_WORLD_79 */
+     0x00, /* 240 SDLK_WORLD_80 */
+     0x00, /* 241 SDLK_WORLD_81 */
+     0x00, /* 242 SDLK_WORLD_82 */
+     0x00, /* 243 SDLK_WORLD_83 */
+     0x00, /* 244 SDLK_WORLD_84 */
+     0x00, /* 245 SDLK_WORLD_85 */
+     0x00, /* 246 SDLK_WORLD_86 */
+     0x00, /* 247 SDLK_WORLD_87 */
+     0x00, /* 248 SDLK_WORLD_88 */
+     0x00, /* 249 SDLK_WORLD_89 */
+     0x00, /* 250 SDLK_WORLD_90 */
+     0x00, /* 251 SDLK_WORLD_91 */
+     0x00, /* 252 SDLK_WORLD_92 */
+     0x00, /* 253 SDLK_WORLD_93 */
+     0x00, /* 254 SDLK_WORLD_94 */
+     0x00, /* 255 SDLK_WORLD_95 */
+     
+     0x52,   /* 256 SDLK_KP0 */
+     0x4f,   /* 257 SDLK_KP1 */
+     0x50,   /* 258 SDLK_KP2 */
+     0x51,   /* 259 SDLK_KP3 */
+     0x4b,   /* 260 SDLK_KP4 */
+     0x4c,   /* 261 SDLK_KP5 */
+     0x4d,   /* 262 SDLK_KP6 */
+     0x47,   /* 263 SDLK_KP7 */
+     0x48,   /* 264 SDLK_KP8 */
+     0x49,   /* 265 SDLK_KP9 */
+     0x53,   /* 266 SDLK_KP_PERIOD */
+     0x35e0, /* 267 SDLK_KP_DIVIDE */
+     0x37,   /* 268 SDLK_KP_MULTIPLY */
+     0x4a,   /* 269 SDLK_KP_MINUS */
+     0x4e,   /* 270 SDLK_KP_PLUS */
+     0x1ce0, /* 271 SDLK_KP_ENTER */
+     0x00,   /* 272 SDLK_KP_EQUALS */
+ 
+     0x48e0, /* 273 SDLK_UP */
+     0x50e0, /* 274 SDLK_DOWN */
+     0x4de0, /* 275 SDLK_RIGHT */
+     0x4be0, /* 276 SDLK_LEFT */
+     0x52e0, /* 277 SDLK_INSERT */
+     0x47e0, /* 278 SDLK_HOME */
+     0x4fe0, /* 279 SDLK_END */
+     0x49e0, /* 280 SDLK_PAGEUP */
+     0x51e0, /* 281 SDLK_PAGEDOWN */
+ 
+     0x3b, /* 282 SDLK_F1 */
+     0x3c, /* 283 SDLK_F2 */
+     0x3d, /* 284 SDLK_F3 */
+     0x3e, /* 285 SDLK_F4 */
+     0x3f, /* 286 SDLK_F5 */
+     0x40, /* 287 SDLK_F6 */
+     0x41, /* 288 SDLK_F7 */
+     0x42, /* 289 SDLK_F8 */
+     0x43, /* 290 SDLK_F9 */
+     0x44, /* 291 SDLK_F10 */
+     0x57, /* 292 SDLK_F11 */
+     0x58, /* 293 SDLK_F12 */
+     0x00, /* 294 SDLK_F13 */
+     0x00, /* 295 SDLK_F14 */
+     0x00, /* 296 SDLK_F15 */
+     0x00, /* 297 */
+     0x00, /* 298 */
+     0x00, /* 299 */
+ 
+     0x45,   /* 300 SDLK_NUMLOCK */
+     0x3a,   /* 301 SDLK_CAPSLOCK */
+     0x46,   /* 302 SDLK_SCROLLOCK */
+     0x36,   /* 303 SDLK_RSHIFT */
+     0x2a,   /* 304 SDLK_LSHIFT */
+     0x1de0, /* 305 SDLK_RCTRL */
+     0x1d,   /* 306 SDLK_LCTRL */
+     0x38e0, /* 307 SDLK_RALT */
+     0x38,   /* 308 SDLK_LALT */
+     0x5be0, /* 309 SDLK_RMETA -- Apple Command keys*/
+     0x5ce0, /* 310 SDLK_LMETA */
+     0x5be0, /* 311 SDLK_LSUPER -- Windows keys */
+     0x5ce0, /* 312 SDLK_RSUPER */
+     0x00,   /* 313 SDLK_MODE -- Alt Gr */
+     0x00,   /* 314 SDLK_COMPOSE */
+ 
+     0x00,   /* 315 SDLK_HELP */
+     0x00,   /* 316 SDLK_PRINT */
+     0x00,   /* 317 SDLK_SYSREQ */
+     0x00,   /* 318 SDLK_BREAK */
+     0x5de0, /* 319 SDLK_MENU */
+     0x00,   /* 320 SDLK_POWER */
+     0x00,   /* 321 SDLK_EURO */
+     0x00,   /* 322 SDLK_UNDO */
+ };
+ 
+pp_uint16 toSC(const SDL_keysym& keysym)
+{
+#ifndef NOT_PC_KB
+	// WARNING!!!!
+	// The next line will only work on X11 systems - I've no idea what will happen
+	// with anything else
+	if(isX11 && stdKb)
+		return keysym.scancode - 8;
+	else if(stdKb)
+		return keysym.scancode;
+#endif
+
+	int keycode, v;
+
+    if (keysym.sym > SDLK_LAST) 
+	{
+		keycode = 0;
+	} 
+	else 
+	{
+        keycode = sdl_keycode_to_pc_keycode[keysym.sym];
+	}
+
+	return keycode;
+}

--- a/src/tracker/sdl-1.2/SDL_KeyTranslation.h
+++ b/src/tracker/sdl-1.2/SDL_KeyTranslation.h
@@ -1,0 +1,44 @@
+/*
+ *  tracker/sdl/SDL_KeyTranslation.h
+ *
+ *  Copyright 2009 Peter Barth
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  KeyTranslation.h
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on 19.11.05.
+ *
+ */
+
+#ifndef KEYTRANSLATION__H
+#define KEYTRANSLATION__H
+
+#include <SDL.h>
+#include "BasicTypes.h"
+
+// #define NOT_PC_KB	// Set this if you're using non-PC type keyboard
+
+pp_uint16 toVK(const SDL_keysym& keysym);
+pp_uint16 toSC(const SDL_keysym& keysym);
+extern bool isX11;
+extern bool stdKb;
+
+#endif

--- a/src/tracker/sdl-1.2/SDL_Main.cpp
+++ b/src/tracker/sdl-1.2/SDL_Main.cpp
@@ -1,0 +1,1164 @@
+/* *  tracker/sdl/SDL_Main.cpp
+ *
+ *  Copyright 2009 Peter Barth, Christopher O'Neill
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  SDL_Main.cpp
+ *  MilkyTracker SDL front end
+ *
+ *  Created by Peter Barth on 19.11.05.
+ *
+ * 15/2/08 - Peter Barth
+ *  This code needs major clean up, there are too many workarounds going on
+ *  for different platforms/configurations (MIDI, GP2X etc.)
+ *  Please do not further pollute this single source code when possible
+ *
+ * 14/8/06 - Christopher O'Neill
+ *  Ok, there are so many changes in this file that I've lost track...
+ *  Here are some I remember:
+ *   - ALSA Midi Support
+ *   - GP2X mouse emulator (awaiting a rewrite one day..)
+ *   - Various command line options
+ *   - Fix for french azerty keyboards (their number keys are shifted)
+ * 
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+#include <SDL.h>
+#ifndef __QTOPIA__
+#ifdef HAVE_X11
+#include <SDL_syswm.h>
+#endif
+#endif
+#include "SDL_KeyTranslation.h"
+// ---------------------------- Tracker includes ----------------------------
+#include "PPUI.h"
+#include "DisplayDevice_SDL.h"
+#include "DisplayDeviceFB_SDL.h"
+#ifdef __OPENGL__
+#include "DisplayDeviceOGL_SDL.h"  // <-- Experimental, slow
+#endif
+#include "Screen.h"
+#include "Tracker.h"
+#include "PPMutex.h"
+#include "PPSystem_POSIX.h"
+#include "PPPath_POSIX.h"
+
+#ifdef HAVE_LIBASOUND
+#include "../midi/posix/MidiReceiver_pthread.h"
+#endif
+// --------------------------------------------------------------------------
+
+// SDL surface screen
+SDL_Surface*				screen				= NULL;
+SDL_TimerID	timer;
+
+// Tracker globals
+static PPScreen*			myTrackerScreen		= NULL;
+static Tracker*				myTracker			= NULL;
+static PPDisplayDevice*	    myDisplayDevice		= NULL;
+#ifdef HAVE_LIBASOUND
+static MidiReceiver*		myMidiReceiver		= NULL;
+#endif
+
+// Okay what else do we need?
+PPMutex*			globalMutex				= NULL;
+static PPMutex*		timerMutex				= NULL;
+static bool			ticking					= false;
+
+static pp_uint32	lmyTime;
+static PPPoint		llastClickPosition		= PPPoint(0,0);
+static pp_uint16	lClickCount				= 0;
+
+static pp_uint32	rmyTime;
+static PPPoint		rlastClickPosition		= PPPoint(0,0);
+static pp_uint16	rClickCount				= 0;
+
+static bool			lMouseDown				= false;
+static pp_uint32	lButtonDownStartTime;
+
+static bool			rMouseDown				= false;
+static pp_uint32	rButtonDownStartTime;
+
+static pp_uint32	timerTicker				= 0;
+
+static PPPoint		p;
+
+// This needs to be visible from outside 
+pp_uint32 PPGetTickCount()
+{
+	return SDL_GetTicks();
+}
+
+// Same as above
+void QueryKeyModifiers()
+{
+	pp_uint32 mod = SDL_GetModState();
+
+	if((mod & KMOD_LSHIFT) || (mod & KMOD_RSHIFT))
+		setKeyModifier(KeyModifierSHIFT);
+	else
+		clearKeyModifier(KeyModifierSHIFT);
+	
+	if((mod & KMOD_LCTRL) || (mod & KMOD_RCTRL))
+		setKeyModifier(KeyModifierCTRL);
+	else
+		clearKeyModifier(KeyModifierCTRL);
+
+	if((mod & KMOD_LALT) || (mod & KMOD_RALT))
+		setKeyModifier(KeyModifierALT);
+	else
+		clearKeyModifier(KeyModifierALT);
+}
+
+static void RaiseEventSerialized(PPEvent* event)
+{
+	if (myTrackerScreen && myTracker)
+	{
+		globalMutex->lock();
+		myTrackerScreen->raiseEvent(event);		
+		globalMutex->unlock();
+	}
+}
+
+#ifdef __GP2X__
+struct
+{
+	bool up, down, left, right, upLeft, upRight, downLeft, downRight;
+	pp_int32 x, y;
+	pp_int32 ticks;
+	pp_int32 button;
+} mouse;
+
+void gp2xMouseEvent(const SDL_Event& event)
+{
+	bool buttonPressed;
+	if(event.type == SDL_JOYBUTTONDOWN)
+		buttonPressed = true;
+	else
+		buttonPressed = false;
+
+	switch(event.jbutton.button)
+	{
+		case 0:		// Up
+			mouse.up = buttonPressed;
+			break;
+			
+		case 4: 	// Down
+			mouse.down = buttonPressed;
+			break;
+
+		case 2:		// Left
+			mouse.left = buttonPressed;
+			break;
+	
+		case 6:		// Right
+			mouse.right = buttonPressed;
+			break;
+			
+		case 1:		// upLeft
+			mouse.upLeft = buttonPressed;
+			break;
+			
+		case 7:		// upRight
+			mouse.upRight = buttonPressed;
+			break;
+
+		case 3:		// downLeft
+			mouse.downLeft = buttonPressed;
+			break;
+			
+		case 5:		// downRight
+			mouse.downRight = buttonPressed;
+			break;
+
+		case 18:	// Click
+		case 12:
+			SDL_Event myEvent;
+			if (buttonPressed) 
+			{
+				myEvent.type = SDL_MOUSEBUTTONDOWN;
+				myEvent.button.type = SDL_MOUSEBUTTONDOWN;
+				myEvent.button.state = SDL_PRESSED;
+				mouse.button = 1;
+			} 
+			else 
+			{
+				myEvent.type = SDL_MOUSEBUTTONUP;
+				myEvent.button.type = SDL_MOUSEBUTTONUP;
+				myEvent.button.state = SDL_RELEASED;
+				mouse.button = 0;
+			}
+			myEvent.button.x = mouse.x;
+			myEvent.button.y = mouse.y;
+			myEvent.button.button = SDL_BUTTON_LEFT;
+			SDL_PushEvent(&myEvent);
+			break;
+		
+		case 8:		// Start
+			if (!buttonPressed) 
+			{
+				pp_uint16 chr[3] = {VK_RETURN, 0, 0};
+				PPEvent event(eKeyDown, &chr, sizeof(chr));
+			}
+			break;
+	}
+}
+
+void gp2xMouseMove()
+{
+	const int xMax = 320, yMax = 240;
+	static int oldX = 0, oldY = 0;
+	int step;
+	if(mouse.ticks < 25)
+		step = 1;
+	else if(mouse.ticks < 75)
+		step = 2;
+	else if(mouse.ticks < 125)
+		step = 3;
+
+	if(mouse.up || mouse.upLeft || mouse.upRight) mouse.y -= step;
+	if(mouse.down || mouse.downLeft || mouse.downRight) mouse.y += step;
+	if(mouse.left || mouse.downLeft || mouse.upLeft) mouse.x -= step;
+	if(mouse.right || mouse.downRight || mouse.upRight) mouse.x += step;
+	if(mouse.x == oldX && mouse.y == oldY) {
+		mouse.ticks = 0;
+		return;
+	}
+	oldX = mouse.x; oldY = mouse.y;
+	if(mouse.x > xMax) mouse.x = xMax;
+	if(mouse.x < 0) mouse.x = 0;
+	if(mouse.y > yMax) mouse.y = yMax;
+	if(mouse.y < 0) mouse.y = 0;
+	SDL_WarpMouse(mouse.x, mouse.y);
+	if(mouse.ticks < 125) mouse.ticks++;
+}
+#endif
+
+enum SDLUserEvents
+{
+	SDLUserEventTimer,
+	SDLUserEventLMouseRepeat,
+	SDLUserEventRMouseRepeat,
+	SDLUserEventMidiKeyDown,
+	SDLUserEventMidiKeyUp,
+};
+
+static SDLCALL Uint32 timerCallback(Uint32 interval)
+{
+	timerMutex->lock();
+
+	if (!myTrackerScreen || !myTracker || !ticking)
+	{
+		timerMutex->unlock();
+		return interval;
+	}
+	
+	SDL_UserEvent ev;	
+	ev.type = SDL_USEREVENT;
+
+	if (!(timerTicker % 1))
+	{
+		ev.code = SDLUserEventTimer;
+		SDL_PushEvent((SDL_Event*)&ev);		
+		
+		//PPEvent myEvent(eTimer);
+		//RaiseEventSerialized(&myEvent);
+	}
+	
+	timerTicker++;
+	
+#ifdef __GP2X__
+	gp2xMouseMove();
+#endif
+
+	if (lMouseDown &&
+		(timerTicker - lButtonDownStartTime) > 25)
+	{
+		ev.code = SDLUserEventLMouseRepeat;
+		ev.data1 = (void*)p.x;
+		ev.data2 = (void*)p.y;
+		SDL_PushEvent((SDL_Event*)&ev);		
+
+		//PPEvent myEvent(eLMouseRepeat, &p, sizeof(PPPoint));		
+		//RaiseEventSerialized(&myEvent);
+	}
+
+	if (rMouseDown &&
+		(timerTicker - rButtonDownStartTime) > 25)
+	{
+		ev.code = SDLUserEventRMouseRepeat;
+		ev.data1 = (void*)p.x;
+		ev.data2 = (void*)p.y;
+		SDL_PushEvent((SDL_Event*)&ev);		
+
+		//PPEvent myEvent(eRMouseRepeat, &p, sizeof(PPPoint));		
+		//RaiseEventSerialized(&myEvent);
+	}
+
+	timerMutex->unlock();
+		
+	return interval;
+}
+
+#ifdef HAVE_LIBASOUND
+class MidiEventHandler : public MidiReceiver::MidiEventHandler
+{
+public:
+	virtual void keyDown(int note, int volume) 
+	{
+		SDL_UserEvent ev;	
+		ev.type = SDL_USEREVENT;
+		ev.code = SDLUserEventMidiKeyDown;
+		ev.data1 = (void*)note;
+		ev.data2 = (void*)volume;
+		SDL_PushEvent((SDL_Event*)&ev);		
+
+		//globalMutex->lock();
+		//myTracker->sendNoteDown(note, volume);
+		//globalMutex->unlock();
+	}
+
+	virtual void keyUp(int note) 
+	{
+		SDL_UserEvent ev;	
+		ev.type = SDL_USEREVENT;
+		ev.code = SDLUserEventMidiKeyUp;
+		ev.data1 = (void*)note;
+		SDL_PushEvent((SDL_Event*)&ev);		
+
+		//globalMutex->lock();
+		//myTracker->sendNoteUp(note);
+		//globalMutex->unlock();
+	}
+} midiEventHandler;
+
+
+void StopMidiRecording()
+{
+	if (myMidiReceiver)
+	{
+		myMidiReceiver->stopRecording();
+	}
+}
+
+void StartMidiRecording(unsigned int devID)
+{
+	if (devID == (unsigned)-1)
+		return;
+
+	StopMidiRecording();
+
+	myMidiReceiver = new MidiReceiver(midiEventHandler);
+
+	if (!myMidiReceiver->startRecording(devID))
+	{
+		// Deal with error
+		fprintf(stderr, "Failed to initialise ALSA MIDI support.\n");
+	}
+}
+
+void InitMidi()
+{
+	StartMidiRecording(0);
+}
+#endif
+
+void translateMouseDownEvent(pp_int32 mouseButton, pp_int32 localMouseX, pp_int32 localMouseY)
+{
+	if (mouseButton > 2 || !mouseButton)
+		return;
+	
+	// -----------------------------
+	myDisplayDevice->transform(localMouseX, localMouseY);
+	
+	p.x = localMouseX;
+	p.y = localMouseY;
+	
+	if (mouseButton == 1)
+	{
+		PPEvent myEvent(eLMouseDown, &p, sizeof(PPPoint));
+		
+		RaiseEventSerialized(&myEvent);
+		
+		lMouseDown = true;
+		lButtonDownStartTime = timerTicker;
+		
+		if (!lClickCount)
+		{
+			lmyTime = PPGetTickCount();
+			llastClickPosition.x = localMouseX;
+			llastClickPosition.y = localMouseY;
+		}
+		else if (lClickCount == 2)
+		{
+			pp_uint32 deltat = PPGetTickCount() - lmyTime;
+			
+			if (deltat > 500)
+			{
+				lClickCount = 0;
+				lmyTime = PPGetTickCount();
+				llastClickPosition.x = localMouseX;
+				llastClickPosition.y = localMouseY;
+			}
+		}
+		
+		lClickCount++;	
+		
+	}
+	else if (mouseButton == 2)
+	{
+		PPEvent myEvent(eRMouseDown, &p, sizeof(PPPoint));
+		
+		RaiseEventSerialized(&myEvent);
+		
+		rMouseDown = true;
+		rButtonDownStartTime = timerTicker;
+		
+		if (!rClickCount)
+		{
+			rmyTime = PPGetTickCount();
+			rlastClickPosition.x = localMouseX;
+			rlastClickPosition.y = localMouseY;
+		}
+		else if (rClickCount == 2)
+		{
+			pp_uint32 deltat = PPGetTickCount() - rmyTime;
+			
+			if (deltat > 500)
+			{
+				rClickCount = 0;
+				rmyTime = PPGetTickCount();
+				rlastClickPosition.x = localMouseX;
+				rlastClickPosition.y = localMouseY;
+			}
+		}
+		
+		rClickCount++;	
+	}
+}
+
+void translateMouseUpEvent(pp_int32 mouseButton, pp_int32 localMouseX, pp_int32 localMouseY)
+{
+	myDisplayDevice->transform(localMouseX, localMouseY);
+
+	if (mouseButton == SDL_BUTTON_WHEELDOWN)
+	{
+		TMouseWheelEventParams mouseWheelParams;
+		mouseWheelParams.pos.x = localMouseX;
+		mouseWheelParams.pos.y = localMouseY;
+		mouseWheelParams.delta = -1;
+		
+		PPEvent myEvent(eMouseWheelMoved, &mouseWheelParams, sizeof(mouseWheelParams));						
+		RaiseEventSerialized(&myEvent);				
+	}
+	else if (mouseButton == SDL_BUTTON_WHEELUP)
+	{
+		TMouseWheelEventParams mouseWheelParams;
+		mouseWheelParams.pos.x = localMouseX;
+		mouseWheelParams.pos.y = localMouseY;
+		mouseWheelParams.delta = 1;
+		
+		PPEvent myEvent(eMouseWheelMoved, &mouseWheelParams, sizeof(mouseWheelParams));						
+		RaiseEventSerialized(&myEvent);				
+	}
+	else if (mouseButton > 2 || !mouseButton)
+		return;
+	
+	// -----------------------------
+	if (mouseButton == 1)
+	{
+		lClickCount++;
+		
+		if (lClickCount >= 4)
+		{
+			pp_uint32 deltat = PPGetTickCount() - lmyTime;
+			
+			if (deltat < 500)
+			{
+				p.x = localMouseX; p.y = localMouseY;				
+				if (abs(p.x - llastClickPosition.x) < 4 &&
+					abs(p.y - llastClickPosition.y) < 4)
+				{					
+					PPEvent myEvent(eLMouseDoubleClick, &p, sizeof(PPPoint));					
+					RaiseEventSerialized(&myEvent);
+				}
+			}
+			
+			lClickCount = 0;							
+		}
+		
+		p.x = localMouseX; p.y = localMouseY;		
+		PPEvent myEvent(eLMouseUp, &p, sizeof(PPPoint));		
+		RaiseEventSerialized(&myEvent);		
+		lMouseDown = false;
+	}
+	else if (mouseButton == 2)
+	{
+		rClickCount++;
+		
+		if (rClickCount >= 4)
+		{
+			pp_uint32 deltat = PPGetTickCount() - rmyTime;
+			
+			if (deltat < 500)
+			{
+				p.x = localMouseX; p.y = localMouseY;				
+				if (abs(p.x - rlastClickPosition.x) < 4 &&
+					abs(p.y - rlastClickPosition.y) < 4)
+				{					
+					PPEvent myEvent(eRMouseDoubleClick, &p, sizeof(PPPoint));					
+					RaiseEventSerialized(&myEvent);
+				}
+			}
+			
+			rClickCount = 0;
+		}
+		
+		p.x = localMouseX; p.y = localMouseY;		
+		PPEvent myEvent(eRMouseUp, &p, sizeof(PPPoint));		
+		RaiseEventSerialized(&myEvent);		
+		rMouseDown = false;
+	}
+}	
+
+void translateMouseMoveEvent(pp_int32 mouseButton, pp_int32 localMouseX, pp_int32 localMouseY)
+{
+	myDisplayDevice->transform(localMouseX, localMouseY);
+
+	if (mouseButton == 0)
+	{
+		p.x = localMouseX; p.y = localMouseY;
+		PPEvent myEvent(eMouseMoved, &p, sizeof(PPPoint));						
+		RaiseEventSerialized(&myEvent);
+	}
+	else
+	{
+		if (mouseButton > 2 || !mouseButton)
+			return;
+		
+		p.x = localMouseX; p.y = localMouseY;		
+		if (mouseButton == 1 && lMouseDown)
+		{
+			PPEvent myEvent(eLMouseDrag, &p, sizeof(PPPoint));			
+			RaiseEventSerialized(&myEvent);
+		}
+		else if (rMouseDown)
+		{
+			PPEvent myEvent(eRMouseDrag, &p, sizeof(PPPoint));			
+			RaiseEventSerialized(&myEvent);
+		}
+	}
+}
+
+void preTranslateKey(SDL_keysym& keysym)
+{
+	// Rotate cursor keys if necessary
+	switch (myDisplayDevice->getOrientation())
+	{
+		case PPDisplayDevice::ORIENTATION_ROTATE90CW:	
+			switch (keysym.sym)
+			{
+				case SDLK_UP:
+					keysym.sym = SDLK_LEFT;
+					break;
+				case SDLK_DOWN:
+					keysym.sym = SDLK_RIGHT;
+					break;
+				case SDLK_LEFT:
+					keysym.sym = SDLK_DOWN;
+					break;
+				case SDLK_RIGHT:
+					keysym.sym = SDLK_UP;
+					break;
+			}
+		
+			break;
+
+		case PPDisplayDevice::ORIENTATION_ROTATE90CCW:	
+			switch (keysym.sym)
+			{
+				case SDLK_DOWN:
+					keysym.sym = SDLK_LEFT;
+					break;
+				case SDLK_UP:
+					keysym.sym = SDLK_RIGHT;
+					break;
+				case SDLK_RIGHT:
+					keysym.sym = SDLK_DOWN;
+					break;
+				case SDLK_LEFT:
+					keysym.sym = SDLK_UP;
+					break;
+			}
+		
+			break;
+	}
+
+}
+
+void translateKeyDownEvent(const SDL_Event& event)
+{
+	SDL_keysym keysym = event.key.keysym;
+
+	// ALT+RETURN = Fullscreen toggle
+	if (keysym.sym == SDLK_RETURN && (keysym.mod & KMOD_LALT)) 
+	{
+		PPEvent myEvent(eFullScreen);
+		RaiseEventSerialized(&myEvent);
+		return;
+	}
+	
+	preTranslateKey(keysym);
+
+	pp_uint16 character = event.key.keysym.unicode;	
+
+	pp_uint16 chr[3] = {toVK(keysym), toSC(keysym), character};
+
+#ifndef NOT_PC_KB
+	// Hack for azerty keyboards (num keys are shifted, so we use the scancodes)
+	if (stdKb) 
+	{
+		if (chr[1] >= 2 && chr[1] <= 10)
+			chr[0] = chr[1] + 47;	// 1-9
+		else if (chr[1] == 11)
+			chr[0] = 48;			// 0
+	}
+#endif
+	
+	PPEvent myEvent(eKeyDown, &chr, sizeof(chr));
+	RaiseEventSerialized(&myEvent);
+
+	if(character == 127) character = VK_BACK;
+	
+	if (character >= 32 && character <= 127)
+	{
+		PPEvent myEvent2(eKeyChar, &character, sizeof(character));
+		RaiseEventSerialized(&myEvent2);	
+	}
+}
+
+void translateKeyUpEvent(const SDL_Event& event)
+{
+	SDL_keysym keysym = event.key.keysym;
+
+	preTranslateKey(keysym);
+
+	pp_uint16 character = event.key.keysym.unicode;	
+
+	pp_uint16 chr[3] = {toVK(keysym), toSC(keysym), character};
+
+#ifndef NOT_PC_KB
+	if (stdKb) 
+	{
+		if(chr[1] >= 2 && chr[1] <= 10)
+			chr[0] = chr[1] + 47;
+		else if(chr[1] == 11)
+			chr[0] = 48;
+	}
+#endif
+	
+	PPEvent myEvent(eKeyUp, &chr, sizeof(chr));	
+	RaiseEventSerialized(&myEvent);	
+}
+
+void processSDLEvents(const SDL_Event& event)
+{
+	pp_uint32 mouseButton = 0;
+
+	switch (event.type)
+	{
+		case SDL_MOUSEBUTTONDOWN:
+			mouseButton = event.button.button;
+			if (mouseButton > 1 && mouseButton <= 3)
+				mouseButton = 2;
+			translateMouseDownEvent(mouseButton, event.button.x, event.button.y);
+			break;
+			
+		case SDL_MOUSEBUTTONUP:
+			mouseButton = event.button.button;
+			if (mouseButton > 1 && mouseButton <= 3)
+				mouseButton = 2;
+			translateMouseUpEvent(mouseButton, event.button.x, event.button.y);	
+			break;
+			
+		case SDL_MOUSEMOTION:
+#ifdef __GP2X__
+			translateMouseMoveEvent(mouse.button, event.motion.x, event.motion.y);
+#else
+			translateMouseMoveEvent(event.button.button, event.motion.x, event.motion.y);	
+#endif
+			break;
+			
+		case SDL_KEYDOWN:
+			translateKeyDownEvent(event);
+			break;
+
+		case SDL_KEYUP:
+			translateKeyUpEvent(event);
+			break;
+
+#ifdef __GP2X__
+		case SDL_JOYBUTTONDOWN:
+		case SDL_JOYBUTTONUP:
+			gp2xMouseEvent(event);
+			break;
+#endif
+	}
+}
+
+void processSDLUserEvents(const SDL_UserEvent& event)
+{
+	union {
+		void *ptr;
+		pp_int32 i32;
+	} data1, data2;
+	data1.ptr = event.data1;
+	data2.ptr = event.data2;
+
+	switch (event.code)
+	{
+		case SDLUserEventTimer:
+		{
+			PPEvent myEvent(eTimer);
+			RaiseEventSerialized(&myEvent);
+			break;
+		}
+
+		case SDLUserEventLMouseRepeat:
+		{
+			PPPoint p;
+			p.x = data1.i32;
+			p.y = data2.i32;
+			PPEvent myEvent(eLMouseRepeat, &p, sizeof(PPPoint));		
+			RaiseEventSerialized(&myEvent);
+			break;
+		}
+			
+		case SDLUserEventRMouseRepeat:
+		{
+			PPPoint p;
+			p.x = data1.i32;
+			p.y = data2.i32;
+			PPEvent myEvent(eRMouseRepeat, &p, sizeof(PPPoint));		
+			RaiseEventSerialized(&myEvent);
+			break;
+		}
+
+		case SDLUserEventMidiKeyDown:
+		{
+			pp_int32 note = data1.i32;
+			pp_int32 volume = data2.i32;
+			globalMutex->lock();
+			myTracker->sendNoteDown(note, volume);
+			globalMutex->unlock();
+			break;
+		}
+
+		case SDLUserEventMidiKeyUp:
+		{
+			pp_int32 note = data1.i32;
+			globalMutex->lock();
+			myTracker->sendNoteUp(note);
+			globalMutex->unlock();
+			break;
+		}
+
+	}
+}
+
+#ifdef __unix__
+void crashHandler(int signum) 
+{
+	// Save backup.xm
+	static char buffer[1024]; // Should be enough :p
+	strncpy(buffer, getenv("HOME"), 1010);
+	strcat(buffer, "/BACKUP00.XM");
+	struct stat statBuf;
+	int num = 1;
+	while(stat(buffer, &statBuf) == 0 && num <= 100)
+		snprintf(buffer, sizeof(buffer), "%s/BACKUP%02i.XM", getenv("HOME"), num++);
+
+	if (signum == 15) 
+	{
+		fprintf(stderr, "\nTERM signal received.\n");
+		SDL_Quit();
+		return;
+	} 
+	else
+	{
+		fprintf(stderr, "\nCrashed with signal %i\n"
+				"Please submit a bug report stating exactly what you were doing "
+				"at the time of the crash, as well as the above signal number. "
+				"Also note if it is possible to reproduce this crash.\n", signum);
+	}
+
+	if (num != 100) 
+	{
+		if (myTracker->saveModule(buffer) == MP_DEVICE_ERROR)
+		{
+			fprintf(stderr, "\nUnable to save backup (read-only filesystem?)\n\n");
+		}
+		else
+		{
+			fprintf(stderr, "\nA backup has been saved to %s\n\n", buffer);
+		}
+	}
+	
+	// Try and quit SDL
+	SDL_Quit();
+}
+#endif
+
+void initTracker(pp_uint32 bpp, PPDisplayDevice::Orientations orientation, 
+				 bool swapRedBlue, bool fullScreen, bool noSplash)
+{
+	/* Initialize SDL */
+	if ( SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0 ) 
+	{
+		fprintf(stderr, "Couldn't initialize SDL: %s\n",SDL_GetError());
+		exit(1);
+	}
+	// atexit(SDL_Quit);	Not really needed, and needs a wrapper for OS/2
+
+#ifdef __GP2X__
+	if ( SDL_Init(SDL_INIT_JOYSTICK) < 0 || !SDL_JoystickOpen(0)) 
+	{
+		fprintf(stderr, "Couldn't initialize SDL Joystick: %s\n",SDL_GetError());
+		exit(1);
+	}
+	mouse.x = 0;
+	mouse.y = 0;
+	mouse.ticks = 0;
+	mouse.button = 0;
+#endif
+
+	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,
+	                    SDL_DEFAULT_REPEAT_INTERVAL);
+						
+	SDL_EnableUNICODE(1);
+
+#if (defined(unix) || defined(__unix__) || defined(_AIX) || defined(__OpenBSD__)) && \
+    (!defined(__CYGWIN32__) && !defined(ENABLE_NANOX) && \
+     !defined(__QNXNTO__) && !defined(__AROS__))
+
+	// Initialise crash handler
+	struct sigaction act;
+	struct sigaction oldAct;
+	memset(&act, 0, sizeof(act));
+	act.sa_handler = crashHandler;
+	act.sa_flags = SA_RESETHAND;
+	sigaction(SIGTERM | SIGILL | SIGABRT | SIGFPE | SIGSEGV, &act, &oldAct);
+	sigaction(SIGILL, &act, &oldAct);
+	sigaction(SIGABRT, &act, &oldAct);
+	sigaction(SIGFPE, &act, &oldAct);
+	sigaction(SIGSEGV, &act, &oldAct);
+#endif
+	
+#if defined(HAVE_X11) && !defined(__QTOPIA__)
+	SDL_SysWMinfo info;
+	SDL_VERSION(&info.version);
+	if ( SDL_GetWMInfo(&info) && info.subsystem == SDL_SYSWM_X11)
+		isX11 = true;	// Used in SDL_KeyTranslation.cpp
+#endif
+
+	SDL_WM_SetCaption("Loading MilkyTracker...", "MilkyTracker");
+	// ------------ initialise tracker ---------------
+	myTracker = new Tracker();
+
+	PPSize windowSize = myTracker->getWindowSizeFromDatabase();
+ 	if (!fullScreen) 
+		fullScreen = myTracker->getFullScreenFlagFromDatabase();
+	pp_int32 scaleFactor = myTracker->getScreenScaleFactorFromDatabase();
+
+#ifdef __LOWRES__
+	windowSize.width = DISPLAYDEVICE_WIDTH;
+	windowSize.height = DISPLAYDEVICE_HEIGHT;
+#endif
+
+#ifdef __OPENGL__
+	myDisplayDevice = new PPDisplayDeviceOGL(screen, windowSize.width, windowSize.height, 1, bpp, fullScreen, orientation, swapRedBlue);
+#else
+	myDisplayDevice = new PPDisplayDeviceFB(screen, windowSize.width, windowSize.height, scaleFactor, 
+											bpp, fullScreen, orientation, swapRedBlue);
+#endif 
+	
+	myDisplayDevice->init();
+
+	myTrackerScreen = new PPScreen(myDisplayDevice, myTracker);
+	myTracker->setScreen(myTrackerScreen);
+
+#ifdef __QTOPIA__
+	// On Qtopia I have to run a short event loop
+	// until drawing/blitting can be performed
+	// so the splash screen will be visible
+	for (pp_int32 i = 0; i < 500; i++)
+	{
+		SDL_Event event;
+		SDL_PollEvent(&event);
+	}
+#endif
+	
+	// Startup procedure
+	myTracker->startUp(noSplash);
+
+#ifdef HAVE_LIBASOUND
+	InitMidi();
+#endif
+
+	// try to create timer
+	SDL_SetTimer(20, timerCallback);	
+
+	timerMutex->lock();
+	ticking = true;
+	timerMutex->unlock();
+}
+
+static bool done;
+
+void exitSDLEventLoop(bool serializedEventInvoked/* = true*/)
+{
+	PPEvent event(eAppQuit);
+	RaiseEventSerialized(&event);
+	
+	// it's necessary to make this mutex lock because the SDL modal event loop
+	// used in the modal dialogs expects modal dialogs to be invoked by
+	// events within these mutex lock calls
+	if (!serializedEventInvoked)
+		globalMutex->lock();
+		
+	bool res = myTracker->shutDown();
+	
+	if (!serializedEventInvoked)
+		globalMutex->unlock();
+	
+	if (res)
+		done = 1;
+}
+
+void SendFile(char *file)
+{
+	PPSystemString finalFile(file);
+	PPSystemString* strPtr = &finalFile;
+		
+	PPEvent event(eFileDragDropped, &strPtr, sizeof(PPSystemString*));
+	RaiseEventSerialized(&event);		
+}
+
+#if defined(__PSP__)
+extern "C" int SDL_main(int argc, char *argv[])
+#else
+int main(int argc, char *argv[])
+#endif
+{
+	Uint32 videoflags;	
+	SDL_Event event;
+	char *loadFile = 0;
+	
+	pp_int32 defaultBPP = -1;
+	PPDisplayDevice::Orientations orientation = PPDisplayDevice::ORIENTATION_NORMAL;
+	bool swapRedBlue = false, fullScreen = false, noSplash = false;
+	bool recVelocity = false;
+	
+	// Parse command line
+	while ( argc > 1 ) 
+	{
+		--argc;
+		if ( strcmp(argv[argc-1], "-bpp") == 0 ) 
+		{
+			defaultBPP = atoi(argv[argc]);
+			--argc;
+		}
+		else if ( strcmp(argv[argc], "-nosplash") == 0 ) 
+		{
+			noSplash = true;
+		} 
+		else if ( strcmp(argv[argc], "-swap") == 0 ) 
+		{
+			swapRedBlue = true;
+		}
+		else if ( strcmp(argv[argc], "-fullscreen") == 0)
+		{
+			fullScreen = true;
+		}
+		else if ( strcmp(argv[argc-1], "-orientation") == 0 ) 
+		{
+			if (strcmp(argv[argc], "NORMAL") == 0)
+			{
+				orientation = PPDisplayDevice::ORIENTATION_NORMAL;
+			}
+			else if (strcmp(argv[argc], "ROTATE90CCW") == 0)
+			{
+				orientation = PPDisplayDevice::ORIENTATION_ROTATE90CCW;
+			}
+			else if (strcmp(argv[argc], "ROTATE90CW") == 0)
+			{
+				orientation = PPDisplayDevice::ORIENTATION_ROTATE90CW;
+			}
+			else 
+				goto unrecognizedCommandLineSwitch;
+			--argc;
+		} 
+		else if ( strcmp(argv[argc], "-nonstdkb") == 0)
+		{
+			stdKb = false;
+		}
+		else if ( strcmp(argv[argc], "-recvelocity") == 0)
+		{
+			recVelocity = true;
+		}
+		else 
+		{
+unrecognizedCommandLineSwitch:
+			if (argv[argc][0] == '-') 
+			{
+				fprintf(stderr, 
+						"Usage: %s [-bpp N] [-swap] [-orientation NORMAL|ROTATE90CCW|ROTATE90CW] [-fullscreen] [-nosplash] [-nonstdkb] [-recvelocity]\n", argv[0]);
+				exit(1);
+			} 
+			else 
+			{
+				loadFile = argv[argc];
+			}
+		}
+	}
+
+	// Workaround for seg-fault in SDL_Init on Eee PC (thanks nostromo)
+	// (see http://forum.eeeuser.com/viewtopic.php?pid=136945)
+#if HAVE_DECL_SDL_PUTENV
+	SDL_putenv("SDL_VIDEO_X11_WMCLASS=Milkytracker");
+#endif
+
+	timerMutex = new PPMutex();
+	globalMutex = new PPMutex();
+	
+	// Store current working path (init routine is likely to change it)
+	PPPath_POSIX path;	
+	PPSystemString oldCwd = path.getCurrent();
+	
+	globalMutex->lock();
+	initTracker(defaultBPP, orientation, swapRedBlue, fullScreen, noSplash);
+	globalMutex->unlock();
+
+#ifdef HAVE_LIBASOUND
+	if (myMidiReceiver && recVelocity)
+	{
+		myMidiReceiver->setRecordVelocity(true);
+	}
+#endif
+
+	if (loadFile) 
+	{
+		PPSystemString newCwd = path.getCurrent();
+		path.change(oldCwd);
+		SendFile(loadFile);
+		path.change(newCwd);
+		pp_uint16 chr[3] = {VK_RETURN, 0, 0};
+		PPEvent event(eKeyDown, &chr, sizeof(chr));
+		RaiseEventSerialized(&event);
+	}
+	
+	/* Main event loop */
+	done = 0;
+	while (!done && SDL_WaitEvent(&event)) 
+	{
+		switch (event.type) 
+		{
+			case SDL_QUIT:
+				exitSDLEventLoop(false);
+				break;
+			case SDL_MOUSEMOTION:
+			{
+				// ignore old mouse motion events in the event queue
+				SDL_Event new_event;
+				
+				if (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0) 
+				{
+					while (SDL_PeepEvents(&new_event, 1, SDL_GETEVENT, SDL_EVENTMASK(SDL_MOUSEMOTION)) > 0);
+					processSDLEvents(new_event);
+				} 
+				else 
+				{
+					processSDLEvents(event);
+				}
+				break;
+			}
+
+			case SDL_USEREVENT:
+				processSDLUserEvents((const SDL_UserEvent&)event);
+				break;
+
+			default:
+				processSDLEvents(event);
+				break;
+		}
+	}
+
+#ifdef __GP2X__
+	SDL_JoystickClose(0);
+#endif
+
+	timerMutex->lock();
+	ticking = false;
+	timerMutex->unlock();
+
+	SDL_SetTimer(0, NULL);
+	
+	timerMutex->lock();
+	globalMutex->lock();
+#ifdef HAVE_LIBASOUND
+	delete myMidiReceiver;
+#endif
+	delete myTracker;
+	myTracker = NULL;
+	delete myTrackerScreen;
+	myTrackerScreen = NULL;
+	delete myDisplayDevice;
+	globalMutex->unlock();
+	timerMutex->unlock();
+	SDL_Quit();
+	delete globalMutex;
+	delete timerMutex;
+	
+	/* Quoting from README.Qtopia (Application Porting Notes):
+	One thing I have noticed is that applications sometimes don't exit
+	correctly. Their icon remains in the taskbar and they tend to
+	relaunch themselves automatically. I believe this problem doesn't
+	occur if you exit your application using the exit() method. However,
+	if you end main() with 'return 0;' or so, this seems to happen.
+	*/
+#ifdef __QTOPIA__
+	exit(0);
+#else
+	return 0;
+#endif
+}


### PR DESCRIPTION
This is my attempt at keeping MilkyTracker backwards compatible with legacy systems that doesn't support SDL2. I've mainly done this as I am maintaining the MilkyTracker ports for Amiga based OS'es, which of the majority doesn't support SDL-2. 

I know this could be done prettier as there are so many minor differences, but here's what I've come up with.

I intend to push my changes for the Amiga platforms to upstream too, but this will be the first step towards that. And I also believe that other retro/legacy systems would benefit from this!

Thanks!

Regards
Marlon Beijer
