### PR TITLE
Try to load JACK with multiple lib names

### DIFF
--- a/src/milkyplay/drivers/jack/AudioDriver_JACK.cpp
+++ b/src/milkyplay/drivers/jack/AudioDriver_JACK.cpp
@@ -92,7 +92,13 @@ AudioDriver_JACK::~AudioDriver_JACK()
 mp_sint32 AudioDriver_JACK::initDevice(mp_sint32 bufferSizeInWords, mp_uint32 mixFrequency, MasterMixer* mixer)
 {
 	// First load libjack
-	libJack = dlopen("libjack.so", RTLD_LAZY);
+	const char *libJackNames[] = {"libjack.so", "libjack.so.0", NULL};
+	libJack = NULL;
+	for(const char **p = libJackNames; !libJack && *p; ++p) {
+		libJack = dlopen(*p, RTLD_LAZY);
+		fprintf(stderr, "JACK: Attempt to load \"%s\": %s\n", *p, libJack ? "success" : "failure");
+	}
+
 	if(!libJack) {
 		fprintf(stderr, "JACK: Can't load libjack (is it installed?)\n");
 		return -1;


### PR DESCRIPTION
On a Debian system where the jack developer package is not installed, "libjack.so" is not available but "libjack.so.0" is.
notify @trebmuh 