### PR TITLE
bugfix?: sample timestamp incorrect leading zero behavior

### DIFF
--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -273,7 +273,7 @@ pp_uint32 SampleEditorControl::getRepeatLength() const
 	return sampleEditor->getRepeatLength(); 
 }
 
-void SampleEditorControl::formatMillis(char* buffer, pp_uint32 millis)
+void SampleEditorControl::formatMillis(char* buffer, size_t size, pp_uint32 millis)
 {
 	if (millis >= 1000)
 	{
@@ -283,16 +283,16 @@ void SampleEditorControl::formatMillis(char* buffer, pp_uint32 millis)
 		{
 			pp_uint32 mins = secs / 60;
 			secs %= 60;
-			sprintf(buffer, "%im%i.%is", mins, secs, millis);
+			snprintf(buffer, size, "%im%02i.%03is", mins, secs, millis);
 		}
 		else		
-			sprintf(buffer, "%i.%is", secs, millis);
+			snprintf(buffer, size, "%i.%03is", secs, millis);
 	}
 	else
-		sprintf(buffer, "%ims", millis);	
+		snprintf(buffer, size, "%ims", millis);
 }
 
-void SampleEditorControl::formatMillisFraction(char* buffer, pp_uint32 millis, pp_uint32 totalMillis)
+void SampleEditorControl::formatMillisFraction(char* buffer, size_t size, pp_uint32 millis, pp_uint32 totalMillis)
 {
 	if (totalMillis >= 1000)
 	{
@@ -306,13 +306,13 @@ void SampleEditorControl::formatMillisFraction(char* buffer, pp_uint32 millis, p
 			pp_uint32 totalMins = totalSecs / 60;
 			secs %= 60;
 			totalSecs %= 60;
-			sprintf(buffer, "%im%i.%is / %im%i.%is", mins, secs, millis, totalMins, totalSecs, totalMillis);
+			snprintf(buffer, size, "%im%02i.%03is / %im%02i.%03is", mins, secs, millis, totalMins, totalSecs, totalMillis);
 		}
 		else
-			sprintf(buffer, "%i.%is / %i.%is", secs, millis, totalSecs, totalMillis);
+			snprintf(buffer, size, "%i.%03is / %i.%03is", secs, millis, totalSecs, totalMillis);
 	}
 	else
-		sprintf(buffer, "%ims / %ims", millis, totalMillis);
+		snprintf(buffer, size, "%ims / %ims", millis, totalMillis);
 }
 
 void SampleEditorControl::paint(PPGraphicsAbstract* g)
@@ -512,7 +512,7 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 	else if (offsetFormat == OffsetFormatMillis)
 	{
 		pp_uint32 millis = sampleEditor->convertSmpPosToMillis((mp_sint32)ceil(startPos*xScale), relativeNote);
-		formatMillis(buffer, millis);
+		formatMillis(buffer, sizeof(buffer), millis);
 	}
 
 	PPFont* font = PPFont::getFont(PPFont::FONT_TINY);
@@ -537,7 +537,7 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 		{
 			pp_uint32 millis = sampleEditor->convertSmpPosToMillis(positionToSample(currentPosition), relativeNote);
 			pp_uint32 totalMillis = sampleEditor->convertSmpPosToMillis(end, relativeNote);
-			formatMillisFraction(buffer, millis, totalMillis);
+			formatMillisFraction(buffer, sizeof(buffer), millis, totalMillis);
 		}
 	}
 	else
@@ -549,7 +549,7 @@ void SampleEditorControl::paint(PPGraphicsAbstract* g)
 		else if (offsetFormat == OffsetFormatMillis)
 		{
 			pp_uint32 totalMillis = sampleEditor->convertSmpPosToMillis(end, relativeNote);
-			formatMillis(buffer, totalMillis);
+			formatMillis(buffer, sizeof(buffer), totalMillis);
 		}
 	}
 

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -133,8 +133,8 @@ public:
 	void setBackgroundColor(const PPColor& color) { backgroundColor = color; }
 	void setBorderColor(const PPColor& color) { borderColor = &color; }
 
-	static void formatMillis(char* buffer, pp_uint32 millis);
-	static void formatMillisFraction(char* buffer, pp_uint32 millis, pp_uint32 totalMillis);
+	static void formatMillis(char* buffer, size_t size, pp_uint32 millis);
+	static void formatMillisFraction(char* buffer, size_t size, pp_uint32 millis, pp_uint32 totalMillis);
 
 	// from PPControl
 	virtual void paint(PPGraphicsAbstract* graphics);	

--- a/src/tracker/SectionSamples.cpp
+++ b/src/tracker/SectionSamples.cpp
@@ -1315,9 +1315,10 @@ void SectionSamples::setOffsetText(pp_uint32 ID, pp_uint32 offset)
 		{
 			pp_uint32 millis = sampleEditorControl->getSampleEditor()->convertSmpPosToMillis(offset, currentSamplePlayNote - ModuleEditor::MAX_NOTE/2);
 			char buffer[32], buffer2[32];
+
 			memset(buffer2, 32, sizeof(buffer2));
 			// we only have 7 digits, one period character is contained too
-			SampleEditorControl::formatMillis(buffer, millis % 10000000);
+			SampleEditorControl::formatMillis(buffer, sizeof(buffer), millis % 10000000);
 			// string too large
 			if (strlen(buffer) > 8)
 			{


### PR DESCRIPTION
Fix for: https://github.com/milkytracker/MilkyTracker/issues/191

I have no idea if this bugfix doesn't introduce more bugs, I don't even know how to test if `formatMillisFraction` works. But `formatMillis` seems to!

I'm also not sure if replacing those `sprintf` with `snprintf` is a good idea with regards to the future of the codebase.

But hey, _**it works for me!**_ 