### PR TITLE
Fix: Convert CBA panning values

### DIFF
--- a/src/milkyplay/LoaderCBA.cpp
+++ b/src/milkyplay/LoaderCBA.cpp
@@ -83,6 +83,7 @@ static void convertEffect(mp_ubyte& eff, mp_ubyte& op)
 
 		case 0x09:  // set panning
 			eff = 0x08;
+			op = XModule::vol128to255(op);
 			break;
 		
 		case 0x0a:  // sample offset


### PR DESCRIPTION
Fixes: https://github.com/milkytracker/MilkyTracker/issues/196

Converts the panning effect range from 0-128 to 0-255 for CBA files.