### PR TITLE
Bugfix to phase modulation and flanger

### DIFF
--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -1574,23 +1574,27 @@ void SampleEditor::tool_PHPasteSample(const FilterParameters* par)
 	// this ratio needs to be calculated and compensated.
 	// The frequency will still shift if the ratio is not constant
 	// during a longer sample. Ce la vie.
-	pp_int32 ups=0,downs=0;
+	pp_int32 ups=0,downs=0,zeros=0;
 	for (pp_int32 i = 0; i < clipBoard->getWidth(); i++)
 	{
 		if (clipBoard->getSampleWord(i)<0)
 		{
 			downs++;
 		}
-		else
+		else if (clipBoard->getSampleWord(i)>0)
 		{
 			ups++;
 		}
+		else
+		{
+			zeros++;
+		}
 	}
-	if (!downs)
+	if (!downs and !zeros)
 	{
 		downs++; // div by zero prevention
 	}
-	float phaseRatio = (float)ups/(float)downs;
+	float phaseRatio = ((float)ups+(0.5f*(float)zeros))/((float)downs+(0.5f*(float)zeros));
 	float step;
 	float j = 0.0f;
 	for (pp_int32 i = sStart; i < sEnd; i++)

--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -1596,7 +1596,7 @@ void SampleEditor::tool_PHPasteSample(const FilterParameters* par)
 			zeros++;
 		}
 	}
-	if (!downs and !zeros)
+	if (!downs && !zeros)
 	{
 		downs++; // div by zero prevention
 	}

--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -252,6 +252,7 @@ public:
 	void AMPasteSample();
 	void FMPasteSample();
 	void PHPasteSample();
+	void FLPasteSample();
 	void convertSampleResolution(bool convert);
 
 	// remember to stop playing before using this
@@ -319,6 +320,7 @@ public:
 	void tool_AMPasteSample(const FilterParameters* par);
 	void tool_FMPasteSample(const FilterParameters* par);
 	void tool_PHPasteSample(const FilterParameters* par);
+	void tool_FLPasteSample(const FilterParameters* par);
 	
 	// convert sample resolution
 	void tool_convertSampleResolution(const FilterParameters* par);

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -142,6 +142,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	subMenuXPaste->addEntry("Amp Modulate", MenuCommandIDAMPaste);
 	subMenuXPaste->addEntry("Freq Modulate", MenuCommandIDFMPaste);
 	subMenuXPaste->addEntry("Phase Modulate", MenuCommandIDPHPaste);
+	subMenuXPaste->addEntry("Flanger", MenuCommandIDFLPaste);
 	subMenuXPaste->addEntry("Selective EQ" PPSTR_PERIODS, MenuCommandIDSelectiveEQ10Band);
 
 	subMenuPT = new PPContextMenu(6, parentScreen, this, PPPoint(0,0), TrackerConfig::colorThemeMain);
@@ -1684,6 +1685,7 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	subMenuXPaste->setState(MenuCommandIDAMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDFMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDPHPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
+	subMenuXPaste->setState(MenuCommandIDFLPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDSelectiveEQ10Band, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 
 	subMenuPT->setState(MenuCommandIDPTBoost, isEmptySample);
@@ -1741,6 +1743,11 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 		// PH-paste
 		case MenuCommandIDPHPaste:
 			sampleEditor->PHPasteSample();
+			break;
+
+		// FL-paste
+		case MenuCommandIDFLPaste:
+			sampleEditor->FLPasteSample();
 			break;
 
 		// crop

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -278,6 +278,7 @@ private:
 		MenuCommandIDAMPaste,
 		MenuCommandIDFMPaste,
 		MenuCommandIDPHPaste,
+		MenuCommandIDFLPaste,
 		MenuCommandIDNormalize,
 		MenuCommandIDVolumeBoost,
 		MenuCommandIDVolumeFade,


### PR DESCRIPTION
Hi.

If you remember me, I added those Amplitude Modulation (technically Ring-modulation if lower Halfwave is used, too) Frequency Modulation and "Phase modulation" filters a few years ago.

Phase modulation has a bug, which shifts the frequencies of the to-be-distorted signal in a not-exactly-desired way. I finally fixed it. Frequency of signals should now be more stable.

Also, I added a new filter, a Flanger filter. The flanger basically adds a sample to itself, but phase shifted, the amount of phaseshift comes from the clipboard, which means one can design nice flanger-like-effects by putting apropriate envelopes into the clipboard.

I made a turorial video about all this:

https://www.youtube.com/watch?v=zR_P-2UvkiM

cheers.
