### PR TITLE
Allow specifying a quarter period (0.25) for periods in generator

### DIFF
--- a/src/tracker/SampleEditorControlToolHandler.cpp
+++ b/src/tracker/SampleEditorControlToolHandler.cpp
@@ -158,7 +158,7 @@ bool SampleEditorControl::invokeToolParameterDialog(SampleEditorControl::ToolHan
 			static_cast<DialogWithValues*>(dialog)->setValueOneCaption("Volume in percent:");
 			static_cast<DialogWithValues*>(dialog)->setValueTwoCaption("Number of periods:");
 			static_cast<DialogWithValues*>(dialog)->setValueOneRange(-1000.0f, 1000.0f, 2); 
-			static_cast<DialogWithValues*>(dialog)->setValueTwoRange(0.0f, 1000.0f, 1); 
+			static_cast<DialogWithValues*>(dialog)->setValueTwoRange(0.0f, (float)(1024*1024*5), 2);
 			static_cast<DialogWithValues*>(dialog)->setValueOne(lastValues.waveFormVolume != SampleEditorControlLastValues::invalidFloatValue() ? lastValues.waveFormVolume : 100.0f);
 			static_cast<DialogWithValues*>(dialog)->setValueTwo(lastValues.waveFormNumPeriods != SampleEditorControlLastValues::invalidFloatValue() ? lastValues.waveFormNumPeriods : 1.0f);
 			break;


### PR DESCRIPTION
Putting a quarter period (0.25) of basic wave forms is
useful for autogenerating envelopes for various filters
(Amplitude, Phase, Frequence, Flanger)
But the UI field only allowed 1 digit after decimal point, making that
impossible.

Sensible maximum value is maximum length of sample/2 to fill with
waveform at Nyquist frequency.

Maximum length for a sample in the same UI description file is 1024 * 1024 * 10 -1
so that would be 1024 * 1024 * 5