### PR TITLE
Fix some milkyplay bugs/crashes

### DIFF
--- a/src/milkyplay/ChannelMixer.cpp
+++ b/src/milkyplay/ChannelMixer.cpp
@@ -657,6 +657,8 @@ void ChannelMixer::setNumChannels(mp_uint32 num)
 		mixerNumAllocatedChannels = num;
 		resetChannelsWithoutMuting();
 	}
+
+	mixerNumActiveChannels = num;
 }
 
 void ChannelMixer::setActiveChannels(mp_uint32 num)

--- a/src/milkyplay/ChannelMixer.cpp
+++ b/src/milkyplay/ChannelMixer.cpp
@@ -1196,13 +1196,6 @@ mp_sint32 ChannelMixer::setBufferSize(mp_uint32 bufferSize)
 	if (this->mixBufferSize == bufferSize)
 		return MP_OK;
 
-	if (initialized)
-	{
-		mp_sint32 err = closeDevice();
-		if (err != MP_OK)
-			return err;
-	}
-	
 	this->mixBufferSize = bufferSize;
 	
 	// channels contain information depending up the buffer size

--- a/src/milkyplay/PlayerGeneric.cpp
+++ b/src/milkyplay/PlayerGeneric.cpp
@@ -202,15 +202,16 @@ PlayerGeneric::PlayerGeneric(mp_sint32 frequency, AudioDriverInterface* audioDri
 	
 PlayerGeneric::~PlayerGeneric()
 {
-	if (mixer)
-		delete mixer;
 
 	if (player)
 	{
-		if (mixer->isActive() && !mixer->isDeviceRemoved(player))
+		if (mixer && mixer->isActive() && !mixer->isDeviceRemoved(player))
 			mixer->removeDevice(player);
 		delete player;
 	}
+	
+	if (mixer)
+		delete mixer;
 
 	delete[] audioDriverName;
 	

--- a/src/milkyplay/drivers/sdl/AudioDriver_SDL.cpp
+++ b/src/milkyplay/drivers/sdl/AudioDriver_SDL.cpp
@@ -91,7 +91,9 @@ mp_sint32 AudioDriver_SDL::initDevice(mp_sint32 bufferSizeInWords, mp_uint32 mix
 	// Some soundcard drivers modify the wanted structure, so we copy it here
 	memcpy(&saved, &wanted, sizeof(wanted));
 
-	if(SDL_OpenAudio(&wanted, &obtained) < 0)
+	device = SDL_OpenAudioDevice(NULL, false, &wanted, &obtained, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+
+	if (device == 0)
 	{
 		memcpy(&wanted, &saved, sizeof(wanted));
 		fprintf(stderr, "SDL: Failed to open audio device! (buffer = %d bytes)..\n", saved.samples*4);
@@ -100,19 +102,6 @@ mp_sint32 AudioDriver_SDL::initDevice(mp_sint32 bufferSizeInWords, mp_uint32 mix
 	}
 
 	printf("SDL: Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
-
-	if(wanted.format != obtained.format)
-	{
-		fprintf(stderr, "SDL: Audio driver doesn't support 16-bit signed samples!\n");
-		return MP_DEVICE_ERROR;
-	}
-
-	if (wanted.channels != obtained.channels)
-	{
-		fprintf(stderr, "SDL: Failed to obtain requested audio format.  Suggested format:\n");
-		fprintf(stderr, "SDL: Frequency: %d\nChannels: %d\n", obtained.freq, obtained.channels);
-		return MP_DEVICE_ERROR;
-	}
 
 	// fallback for obtained sample rate
 	if (wanted.freq != obtained.freq)
@@ -130,33 +119,33 @@ mp_sint32 AudioDriver_SDL::initDevice(mp_sint32 bufferSizeInWords, mp_uint32 mix
 
 mp_sint32 AudioDriver_SDL::stop()
 {
-	SDL_PauseAudio(1);
+	SDL_PauseAudioDevice(device, 1);
 	deviceHasStarted = false;
 	return MP_OK;
 }
 
 mp_sint32 AudioDriver_SDL::closeDevice()
 {
-	SDL_CloseAudio();
+	SDL_CloseAudioDevice(device);
 	deviceHasStarted = false;
 	return MP_OK;
 }
 
 mp_sint32 AudioDriver_SDL::start()
 {
-	SDL_PauseAudio(0);
+	SDL_PauseAudioDevice(device, 0);
 	deviceHasStarted = true;
 	return MP_OK;
 }
 
 mp_sint32 AudioDriver_SDL::pause()
 {
-	SDL_PauseAudio(1);
+	SDL_PauseAudioDevice(device, 1);
 	return MP_OK;
 }
 
 mp_sint32 AudioDriver_SDL::resume()
 {
-	SDL_PauseAudio(0);
+	SDL_PauseAudioDevice(device, 0);
 	return MP_OK;
 }

--- a/src/milkyplay/drivers/sdl/AudioDriver_SDL.h
+++ b/src/milkyplay/drivers/sdl/AudioDriver_SDL.h
@@ -46,6 +46,7 @@ class AudioDriver_SDL : public AudioDriver_COMPENSATE
 {
 private:
 	mp_uint32	periodSize;
+	int			device;      // SDL audio device ID
 	
 	static void SDLCALL fill_audio(void *udata, Uint8 *stream, int len); 
 									 


### PR DESCRIPTION
Hi! I've been trying to use milkyplay as a library and ran into several issues. I put together a minimal example using SDL2:

```cpp
#include "SDL.h"
#include "MilkyPlay.h" 
#include "AudioDriver_SDL.h"

int main(int argc, char *argv[]) {
	
	SDL_Init(SDL_INIT_EVERYTHING);
	
	SDL_Window *window = SDL_CreateWindow(
		"MilkyPlay Test",
		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
		800, 480, SDL_WINDOW_SHOWN
	);
	SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
	
	AudioDriver_SDL driver;
	PlayerGeneric player(44100, &driver);
	XModule mod;
	
	if (mod.loadModule("Goodboy4.xm") != MP_OK) {
		printf("Could not open .xm file.\n");
		return 1;
	}
	if (player.startPlaying(&mod) != MP_OK) {
		printf("Failed to start playing!\n");
		return 1;
	}
	
	while (true) {
		SDL_Event e;
		while (SDL_PollEvent(&e)) {
			if (e.type == SDL_QUIT) {
				goto Exit;
			}
		}
		SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
		SDL_RenderClear(renderer);
		SDL_RenderPresent(renderer);
		SDL_Delay(20);
	}
	
	Exit:
	player.stopPlaying();
	SDL_DestroyRenderer(renderer);
	SDL_DestroyWindow(window);
	SDL_Quit();
	return 0;
}
```

Literally so many things went wrong, I can only wonder if I somehow missed a crucial step and forced the library down some untested code path. Or if simply nobody ever ran this code outside of MilkyTracker, where things are set up differently.

### 1. Initialisation fails with "SDL: Audio driver doesn't support 16-bit signed samples!"

`AudioDriver_SDL` has several checks which seem counterproductive. Many computers won't give the desired signed 16-bit format.

We can pass NULL as the second argument to `SDL_OpenAudio`, to force SDL to emulate the desired spec even if it's not natively available. Instead I opted to use [SDL_OpenAudioDevice](https://wiki.libsdl.org/SDL_OpenAudioDevice) which gives control over which parts of the spec are allowed to change.

### 2. Mixer inadvertently closes when setBufferSize() is called during initialisation?

Now we call `startPlaying()`, but nothing happens! I traced it down to here:

```cpp
mp_sint32 ChannelMixer::setBufferSize(mp_uint32 bufferSize)
{
	if (this->mixBufferSize == bufferSize)
		return MP_OK;

	if (initialized)
	{
		mp_sint32 err = closeDevice();
		if (err != MP_OK)
			return err;
	}
	...
```

Seems like `initDevice()` was already called by the time this code runs, so the player gives up. Frustratingly, this occurs inside a listener, so the failure is never reported and `startPlaying()` returns `MP_OK` even though everything is very not OK!

I could not find a suitable _earlier_ place to call `setBufferSize()`, but deleting the whole `if (initialized)` block seems to fix the problem.

### 3. Mixer channels are uninitialised

The app will segfault while mixing. At first I managed to fix it by commenting out the calls to `storeTimeRecordData()` in `ChannelMixer.cpp`. But it seems like I just got lucky, because similar crashes happen further down the line.

According to the debugger, the mixer has 32 channels while my song only has 8? If the remaining channels are uninitialised, that would explain why it crashes on the 9th element, and `chn->sample` gets a rather suspect value of `0xabababababababab` on my machine.

I finally fixed this by making it so that `setNumChannels()` will change the value of `mixerNumActiveChannels`. Now everything seems to be working! But I'm not confident it won't fall over as soon as I want to add or remove channels...

### 4. Bug in `GenericPlayer` destructor

Ah this one was funny. It tries to use the mixer immediately after deleting it! Easy fix :)

-----

Hope these changes are all OK! Am eager for comments on anything I missed or should have done differently.