### PR TITLE
powerpc: don't use asm optimisation with clang

### DIFF
--- a/src/ppui/fastfill.h
+++ b/src/ppui/fastfill.h
@@ -34,8 +34,9 @@ static __attribute__((noinline)) void fill_dword(pp_uint32* buff, pp_uint32 dw, 
 static inline void fill_dword(pp_uint32* buff, pp_uint32 dw, pp_uint32 len)
 #endif
 {
-#if defined(__ppc__) && defined(__GNUC__)
+#if defined(__ppc__) && defined(__GNUC__) && !defined(__clang__)
 	// PPC assembly FTW!!1!
+	// XXX broken with clang
 	// r3 = buff
 	// r4 = dw
 	// r5 = len
@@ -94,7 +95,8 @@ static __attribute__((noinline)) void fill_dword_vertical(pp_uint32* buff, pp_ui
 static inline void fill_dword_vertical(pp_uint32* buff, pp_uint32 dw, pp_uint32 len, pp_uint32 pitch)
 #endif
 {
-#if defined(__ppc__) && defined(__GNUC__)
+#if defined(__ppc__) && defined(__GNUC__) && !defined(__clang__)
+	// XXX broken with clang
 	asm volatile("nop\n" // align loop start to 16 byte boundary
 				 "nop\n" // same
 				 "nop\n" // same


### PR DESCRIPTION
OpenBSD and FreeBSD use clang to build MilkyTracker, and this compiler does not like the asm optimisations used for ppc32/64.

On OpenBSD/macppc (but it seems to be the same on [FreeBSD/powerpc](https://github.com/freebsd/freebsd-ports/blob/master/audio/milkytracker/Makefile#L17)), this generates these errors:

```
conv.c:78:51: error: invalid operand for instruction
DEFINE_CLIPCONVERT_POWERPC(s8,f32, -128.0, 127.0, LFSUX, LBZ_STBUX)
                                                  ^
conv.c:65:16: note: expanded from macro 'LFSUX'
#define LFSUX   "1:     lfsux f0,%1,%6          \n"
                 ^
<inline asm>:4:10: note: instantiated into assembly here
1:      lfsux f0,5,6            
              ^
conv.c:78:1: error: invalid operand for instruction
DEFINE_CLIPCONVERT_POWERPC(s8,f32, -128.0, 127.0, LFSUX, LBZ_STBUX)
^
conv.c:48:4: note: expanded from macro 'DEFINE_CLIPCONVERT_POWERPC'
                "       fsub f1,f0,%3           \n"                     \
                 ^
<inline asm>:5:7: note: instantiated into assembly here
        fsub f1,f0,2        
(and more)    
```

Using `-fno-integrated-as` did not solve the issue, it emits relocations errors. I can't test every platform using clang on ppc32/64 so maybe it would need further OS-filtering, but i wanted more opinions before eventually polishing that PR, or using some different code if my proposal is considered a bad idea :)

CC'ing @pkubaj if he's interested.