### PR TITLE
Click and drag to move selection in pattern editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 # Resources generated with docerator on OSX
 resources/pictures/docicons/osx/MilkyTracker-*.icns
 resources/pictures/docicons/osx/docerator/
+
+# Editor config files
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,9 @@ elseif(WIN32)
             "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MTd"
         )
         set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /MT")
+    else()
+        # For GCC on Windows (using generator "MSYS Makefiles")
+        add_definitions(-DWIN32)
     endif()
 
     # Prevent Windows.h from clashing with the Standard Template Library so we

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,14 @@ elseif(WIN32)
         set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /MT")
     else()
         # For GCC on Windows (using generator "MSYS Makefiles")
-        add_definitions(-DWIN32)
+		add_definitions(-DWIN32)
+
+		# Enable console output for debug builds
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -mconsole")
+
+		# Static linking of libstdc++ / glibc and other possible components
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
     endif()
 
     # Prevent Windows.h from clashing with the Standard Template Library so we

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if(APPLE)
         )
     endif()
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
     # Set variables for generating the Info.plist file
     set(MACOSX_BUNDLE_BUNDLE_VERSION "${VER_FULL}")
@@ -163,12 +163,12 @@ elseif(WIN32)
         set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /MT")
     else()
         # For GCC on Windows (using generator "MSYS Makefiles")
-		add_definitions(-DWIN32)
+        add_definitions(-DWIN32)
 
-		# Enable console output for debug builds
-		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -mconsole")
+        # Enable console output for debug builds
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -mconsole")
 
-		# Static linking of libstdc++ / glibc and other possible components
+        # Static linking of libstdc++ / glibc and other possible components
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
     endif()

--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -195,7 +195,7 @@ if(WIN32)
             )
         else()
             set(ZLIB_LIBRARIES
-                debug ${ZLIB_DESTDIR}/lib/libzlibstaticd.a
+                debug ${ZLIB_DESTDIR}/lib/libzlibstatic.a
                 optimized ${ZLIB_DESTDIR}/lib/libzlibstatic.a
                 CACHE INTERNAL "ZLIB_LIBRARIES"
             )

--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -186,11 +186,20 @@ if(WIN32)
         )
 
         # zlib adds a 'd' suffix to debug builds of the library
-        set(ZLIB_LIBRARIES
-            debug ${ZLIB_DESTDIR}/lib/zlibstaticd.lib
-            optimized ${ZLIB_DESTDIR}/lib/zlibstatic.lib
-            CACHE INTERNAL "ZLIB_LIBRARIES"
-        )
+
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            set(ZLIB_LIBRARIES
+                debug ${ZLIB_DESTDIR}/lib/zlibstaticd.lib
+                optimized ${ZLIB_DESTDIR}/lib/zlibstatic.lib
+                CACHE INTERNAL "ZLIB_LIBRARIES"
+            )
+        else()
+            set(ZLIB_LIBRARIES
+                debug ${ZLIB_DESTDIR}/lib/libzlibstaticd.a
+                optimized ${ZLIB_DESTDIR}/lib/libzlibstatic.a
+                CACHE INTERNAL "ZLIB_LIBRARIES"
+            )
+        endif()
 
         ExternalProject_Add(zlib
             SOURCE_DIR ${ZLIB_SUBMODULE_DIR}

--- a/src/ppui/GraphicsAbstract.h
+++ b/src/ppui/GraphicsAbstract.h
@@ -161,6 +161,10 @@ protected:
 		*a = *b;
 		*b = h;
 	}
+	static pp_int32 modulo(pp_int32 a, pp_int32 b)
+	{
+		return ((a % b + b) % b);
+	}
 
 	pp_int32 width, height;
 
@@ -330,6 +334,41 @@ public:
 	virtual void fillVerticalShaded(const PPColor& colSrc, const PPColor& colDst, bool invertShading)
 	{
 		fillVerticalShaded(currentClipRect, colSrc, colDst, invertShading);
+	}
+	
+	
+	void drawHLineDashed(pp_int32 x1, pp_int32 x2, pp_int32 y, pp_int32 dashLength, pp_int32 dashOffset = 0)
+	{
+		if (x2 < x1)
+			swap(&x1, &x2);
+		
+		pp_int32 head = x1;
+		pp_int32 tail = x1 + dashLength - modulo(dashOffset, dashLength);
+		
+		while (tail < x2)
+		{
+			drawHLine(head, tail-1, y);
+			head = tail;
+			tail += dashLength;
+		}
+		drawHLine(head, x2, y);
+	}
+	
+	void drawVLineDashed(pp_int32 y1, pp_int32 y2, pp_int32 x, pp_int32 dashLength, pp_int32 dashOffset = 0)
+	{
+		if (y2 < y1)
+			swap(&y1, &y2);
+		
+		pp_int32 head = y1;
+		pp_int32 tail = y1 + dashLength - modulo(dashOffset, dashLength);
+		
+		while (tail < y2)
+		{
+			drawVLine(head, tail-1, x);
+			head = tail;
+			tail += dashLength;
+		}
+		drawVLine(head, y2, x);
 	}
 };
 

--- a/src/ppui/GraphicsAbstract.h
+++ b/src/ppui/GraphicsAbstract.h
@@ -342,16 +342,17 @@ public:
 		if (x2 < x1)
 			swap(&x1, &x2);
 		
-		pp_int32 head = x1;
-		pp_int32 tail = x1 + dashLength - modulo(dashOffset, dashLength);
+		pp_int32 tail = x1;
+		pp_int32 head = x1 + dashLength - modulo(dashOffset, dashLength);
 		
-		while (tail < x2)
+		while (head-1 < x2)
 		{
-			drawHLine(head, tail-1, y);
-			head = tail;
-			tail += dashLength;
+			drawHLine(tail, head-1, y);
+			tail = head;
+			head += dashLength;
 		}
-		drawHLine(head, x2, y);
+		if (tail < x2)
+			drawHLine(tail, x2, y);
 	}
 	
 	void drawVLineDashed(pp_int32 y1, pp_int32 y2, pp_int32 x, pp_int32 dashLength, pp_int32 dashOffset = 0)
@@ -359,16 +360,17 @@ public:
 		if (y2 < y1)
 			swap(&y1, &y2);
 		
-		pp_int32 head = y1;
-		pp_int32 tail = y1 + dashLength - modulo(dashOffset, dashLength);
+		pp_int32 tail = y1;
+		pp_int32 head = y1 + dashLength - modulo(dashOffset, dashLength);
 		
-		while (tail < y2)
+		while (head-1 < y2)
 		{
-			drawVLine(head, tail-1, x);
-			head = tail;
-			tail += dashLength;
+			drawVLine(tail, head-1, x);
+			tail = head;
+			head += dashLength;
 		}
-		drawVLine(head, y2, x);
+		if (tail < y2)
+			drawVLine(tail, y2, x);
 	}
 };
 

--- a/src/ppui/Tools.cpp
+++ b/src/ppui/Tools.cpp
@@ -173,3 +173,8 @@ bool PPTools::decodeByteArray(pp_uint8* array, pp_uint32 size, const PPString& s
 	return true;
 }
 
+pp_int32 PPTools::clamp(pp_int32 a, pp_int32 min, pp_int32 max)
+{
+	return (a < min ? min : (a >= max ? max-1 : a));
+}
+

--- a/src/ppui/Tools.h
+++ b/src/ppui/Tools.h
@@ -47,6 +47,8 @@ public:
 	
 	static PPString encodeByteArray(const pp_uint8* array, pp_uint32 size);	
 	static bool decodeByteArray(pp_uint8* array, pp_uint32 size, const PPString& str);
+	
+	static pp_int32 clamp(pp_int32 a, pp_int32 min, pp_int32 max);
 };
 
 #endif

--- a/src/tracker/PatternEditor.cpp
+++ b/src/tracker/PatternEditor.cpp
@@ -213,7 +213,18 @@ bool PatternEditor::hasValidSelection()
 
 bool PatternEditor::selectionContains(const PatternEditorTools::Position& pos)
 {
-	return PatternEditorTools::selectionContains(pattern ,selection.start, selection.end, pos);
+	return PatternEditorTools::selectionContains(pattern, selection.start, selection.end, pos);
+}
+
+bool PatternEditor::canMoveSelection(pp_int32 channels, pp_int32 rows)
+{
+	PatternEditorTools::Position ss = selection.start;
+	PatternEditorTools::Position se = selection.end;
+	ss.channel += channels;
+	ss.row += rows;
+	se.channel += channels;
+	se.row += rows;
+	return PatternEditorTools::hasValidSelection(pattern, ss, se, getNumChannels());
 }
 
 void PatternEditor::selectChannel(pp_int32 channel)

--- a/src/tracker/PatternEditor.cpp
+++ b/src/tracker/PatternEditor.cpp
@@ -1257,7 +1257,7 @@ bool PatternEditor::writeEffect(pp_int32 effNum, pp_uint8 eff, pp_uint8 op,
 	patternTools.setPosition(pattern, cursor.channel, cursor.row);
 	
 	// only write effect, when valid effect 
-	// (0 is not a valid effect in my internal format, arpeggio is mapped to 0x30)
+	// (0 is not a valid effect in my internal format, arpeggio is mapped to 0x20)
 	if (eff)
 		patternTools.setEffect(effNum, eff, op);
 	else
@@ -1290,7 +1290,7 @@ void PatternEditor::writeDirectEffect(pp_int32 effNum, pp_uint8 eff, pp_uint8 op
 	patternTools.setPosition(pattern, track, row);
 	
 	// only write effect, when valid effect 
-	// (0 is not a valid effect in my internal format, arpeggio is mapped to 0x30)
+	// (0 is not a valid effect in my internal format, arpeggio is mapped to 0x20)
 	if (eff)
 		patternTools.setEffect(effNum, eff, op);
 }

--- a/src/tracker/PatternEditor.cpp
+++ b/src/tracker/PatternEditor.cpp
@@ -211,6 +211,11 @@ bool PatternEditor::hasValidSelection()
 	return PatternEditorTools::hasValidSelection(pattern, selection.start, selection.end, getNumChannels());
 }
 
+bool PatternEditor::selectionContains(const PatternEditorTools::Position& pos)
+{
+	return PatternEditorTools::selectionContains(pattern ,selection.start, selection.end, pos);
+}
+
 void PatternEditor::selectChannel(pp_int32 channel)
 {
 	if (pattern == NULL)
@@ -1814,4 +1819,56 @@ void PatternEditor::deleteLine(pp_int32 row)
 	memset((pattern->rows-1)*rowSize + pattern->patternData, 0, rowSize);
 	
 	finishUndo(LastChangeDeleteLine);
+}
+
+
+void PatternEditor::moveSelection(pp_int32 channels, pp_int32 rows)
+{
+	PatternEditorTools::Position targetStart = selection.start;
+	PatternEditorTools::Position targetEnd = selection.end;
+	targetStart.row += rows;
+	targetStart.channel += channels;
+	targetEnd.row += rows;
+	targetEnd.channel += channels;
+	
+	if (!PatternEditorTools::hasValidSelection(pattern, selection.start, selection.end))
+		return;
+	if (!PatternEditorTools::hasValidSelection(pattern, targetStart, targetEnd))
+		return;
+	
+	prepareUndo();
+	
+	PatternEditorTools tools(pattern);
+	tools.moveSelection(selection.start, selection.end, channels, rows, true);
+	
+	selection.start = targetStart;
+	selection.end = targetEnd;
+	
+	finishUndo(LastChangeMoveSelection);
+}
+
+
+void PatternEditor::cloneSelection(pp_int32 channels, pp_int32 rows)
+{
+	PatternEditorTools::Position targetStart = selection.start;
+	PatternEditorTools::Position targetEnd = selection.end;
+	targetStart.row += rows;
+	targetStart.channel += channels;
+	targetEnd.row += rows;
+	targetEnd.channel += channels;
+	
+	if (!PatternEditorTools::hasValidSelection(pattern, selection.start, selection.end))
+		return;
+	if (!PatternEditorTools::hasValidSelection(pattern, targetStart, targetEnd))
+		return;
+	
+	prepareUndo();
+	
+	PatternEditorTools tools(pattern);
+	tools.moveSelection(selection.start, selection.end, channels, rows, false);  // don't erase source notes
+	
+	selection.start = targetStart;
+	selection.end = targetEnd;
+	
+	finishUndo(LastChangeCloneSelection);
 }

--- a/src/tracker/PatternEditor.h
+++ b/src/tracker/PatternEditor.h
@@ -155,6 +155,8 @@ private:
 		LastChangeCut,
 		LastChangePaste,
 		LastChangeDeleteSelection,
+		LastChangeMoveSelection,
+		LastChangeCloneSelection,
 		
 		LastChangeExpandPattern,
 		LastChangeShrinkPattern,
@@ -263,6 +265,7 @@ public:
 	void setSelectionEnd(const PatternEditorTools::Position& pos) { selection.end = pos; }
 	void resetSelection() { selection.reset(); }
 	bool hasValidSelection();
+	bool selectionContains(const PatternEditorTools::Position& pos);
 	void selectChannel(pp_int32 channel);
 	void selectAll();
 
@@ -413,6 +416,10 @@ public:
 	void insertLine(pp_int32 row);
 	void deleteNote(pp_int32 channel, pp_int32 row);
 	void deleteLine(pp_int32 row);
+
+	// --- moving entire selection -------------------------------------------
+	void moveSelection(pp_int32 channels, pp_int32 rows);
+	void cloneSelection(pp_int32 channels, pp_int32 rows);
 
 };
 

--- a/src/tracker/PatternEditor.h
+++ b/src/tracker/PatternEditor.h
@@ -265,6 +265,7 @@ public:
 	void setSelectionEnd(const PatternEditorTools::Position& pos) { selection.end = pos; }
 	void resetSelection() { selection.reset(); }
 	bool hasValidSelection();
+	bool canMoveSelection(pp_int32 channels, pp_int32 rows);
 	bool selectionContains(const PatternEditorTools::Position& pos);
 	void selectChannel(pp_int32 channel);
 	void selectAll();

--- a/src/tracker/PatternEditorClipBoard.cpp
+++ b/src/tracker/PatternEditorClipBoard.cpp
@@ -56,14 +56,14 @@ void PatternEditor::ClipBoard::makeCopy(TXMPattern& pattern, const PatternEditor
 		return;
 
 	// only entire instrument column is allowed
-	if (selectionStart.inner >= 1 && selectionStart.inner<=2)
+	if (selectionStart.inner >= 1 && selectionStart.inner <= 2)
 		selectionStart.inner = 1;
-	if (selectionEnd.inner >= 1 && selectionEnd.inner<=2)
+	if (selectionEnd.inner >= 1 && selectionEnd.inner <= 2)
 		selectionEnd.inner = 2;
 	// only entire volume column can be selected
-	if (selectionStart.inner >= 3 && selectionStart.inner<=4)
+	if (selectionStart.inner >= 3 && selectionStart.inner <= 4)
 		selectionStart.inner = 3;
-	if (selectionEnd.inner >= 3 && selectionEnd.inner<=4)
+	if (selectionEnd.inner >= 3 && selectionEnd.inner <= 4)
 		selectionEnd.inner = 4;
 	
 	selectionWidth = selectionEnd.channel - selectionStart.channel + 1;
@@ -71,6 +71,7 @@ void PatternEditor::ClipBoard::makeCopy(TXMPattern& pattern, const PatternEditor
 
 	mp_sint32 slotSize = pattern.effnum * 2 + 2;
 	
+	// sanity check: only operate on internal XM pattern data
 	ASSERT(slotSize == 6);
 	
 	mp_sint32 rowSizeDst = slotSize*selectionWidth;

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -826,30 +826,44 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 		pp_int32 i2 = selectionEnd.row + moveSelectionRows;
 		pp_int32 j2 = selectionEnd.channel + moveSelectionChannels;
 		
-		pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
-		pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);
+		if (i2 >= 0 && j2 >= 0 && i1 < pattern->rows && j1 < numVisibleChannels)
+		{
+			#define CLAMP(a, min, max) ((a) < (min) ? (min) : ((a) >= (max) ? (max-1) : (a)))
+			
+			i1 = CLAMP(i1, 0, pattern->rows);
+			i2 = CLAMP(i2, 0, pattern->rows);
+			j1 = CLAMP(j1, 0, numVisibleChannels);
+			j2 = CLAMP(j2, 0, numVisibleChannels);
+			
+			#undef CLAMP
+			
+			pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
+			pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);
+			
+			pp_int32 x2 = (location.x + (j2-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionEnd.inner]+cursorSizes[selectionEnd.inner] + (getRowCountWidth() + 3);
+			pp_int32 y2 = (location.y + (i2-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight()*2 + 2);
+			
+			// use a different color for cloning the selection instead of moving it
+			if (::getKeyModifier() & selectionKeyModifier)
+				g->setColor(hiLightPrimary);
+			else
+				g->setColor(textColor);
+			
+			const pp_int32 dashLen = 6;
+			
+			// inner dashed lines
+			g->drawHLineDashed(x1, x2, y1, dashLen, 3);
+			g->drawHLineDashed(x1, x2, y2, dashLen, 3);
+			g->drawVLineDashed(y1, y2, x1, dashLen, 3);
+			g->drawVLineDashed(y1, y2+1, x2, dashLen, 3);
+			
+			// outer dashed lines
+			g->drawHLineDashed(x1-1, x2+1, y1-1, dashLen, 1);
+			g->drawHLineDashed(x1-1, x2+1, y2+1, dashLen, 3);
+			g->drawVLineDashed(y1-1, y2+1, x1-1, dashLen, 1);
+			g->drawVLineDashed(y1-1, y2+2, x2+1, dashLen, 3);
+		}
 		
-		pp_int32 x2 = (location.x + (j2-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionEnd.inner]+cursorSizes[selectionEnd.inner] + (getRowCountWidth() + 3);
-		pp_int32 y2 = (location.y + (i2-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight()*2 + 2);
-		
-		if (::getKeyModifier() & selectionKeyModifier)
-			g->setColor(hiLightPrimary);   // for cloning the selection instead of moving it
-		else
-			g->setColor(textColor);
-		
-		const pp_int32 dashLen = 6;
-		
-		// inner dashed lines
-		g->drawHLineDashed(x1, x2, y1, dashLen, 3);
-		g->drawHLineDashed(x1, x2, y2, dashLen, 3);
-		g->drawVLineDashed(y1, y2, x1, dashLen, 3);
-		g->drawVLineDashed(y1, y2+1, x2, dashLen, 3);
-		
-		// outer dashed lines
-		g->drawHLineDashed(x1-1, x2+1, y1-1, dashLen, 1);
-		g->drawHLineDashed(x1-1, x2+1, y2+1, dashLen, 3);
-		g->drawVLineDashed(y1-1, y2+1, x1-1, dashLen, 1);
-		g->drawVLineDashed(y1-1, y2+2, x2+1, dashLen, 3);
 	}
 	
 	// draw scrollbars

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -853,15 +853,15 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 			
 			// inner dashed lines
 			g->drawHLineDashed(x1, x2, y1, dashLen, 3);
-			g->drawHLineDashed(x1, x2, y2, dashLen, 3);
+			g->drawHLineDashed(x1, x2, y2, dashLen, 3+y2-y1);
 			g->drawVLineDashed(y1, y2, x1, dashLen, 3);
-			g->drawVLineDashed(y1, y2+1, x2, dashLen, 3);
+			g->drawVLineDashed(y1, y2+2, x2, dashLen, 3+x2-x1);
 			
 			// outer dashed lines
 			g->drawHLineDashed(x1-1, x2+1, y1-1, dashLen, 1);
-			g->drawHLineDashed(x1-1, x2+1, y2+1, dashLen, 3);
+			g->drawHLineDashed(x1-1, x2, y2+1, dashLen, 3+y2-y1);
 			g->drawVLineDashed(y1-1, y2+1, x1-1, dashLen, 1);
-			g->drawVLineDashed(y1-1, y2+2, x2+1, dashLen, 3);
+			g->drawVLineDashed(y1-1, y2+2, x2+1, dashLen, 3+x2-x1);
 		}
 		
 	}

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -733,34 +733,6 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 		}
 	}
 	
-	
-	// --------------------- draw moved selection ---------------------
-
-	if (hasValidSelection() && moveSelection)
-	{
-		// location -- screen position of the top-left corner of the pattern editor window
-		pp_int32 moveSelectionRows = moveSelectionFinalPos.row - moveSelectionInitialPos.row;
-		pp_int32 moveSelectionChannels = moveSelectionFinalPos.channel - moveSelectionInitialPos.channel;
-		
-		pp_int32 i1 = selectionStart.row + moveSelectionRows;
-		pp_int32 j1 = selectionStart.channel + moveSelectionChannels;
-		pp_int32 i2 = selectionEnd.row + moveSelectionRows;
-		pp_int32 j2 = selectionEnd.channel + moveSelectionChannels;
-		
-		pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
-		pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);
-		
-		pp_int32 x2 = (location.x + (j2-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionEnd.inner]+cursorSizes[selectionEnd.inner] + (getRowCountWidth() + 3);
-		pp_int32 y2 = (location.y + (i2-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight()*2 + 4);
-		
-		g->setColor(textColor);
-		g->drawHLine(x1, x2, y1);
-		g->drawHLine(x1, x2, y2);
-		g->drawVLine(y1, y2, x1);
-		g->drawVLine(y1, y2 + 1, x2);
-		
-	}
-
 	for (j = startPos; j < numVisibleChannels; j++)
 	{
 
@@ -840,6 +812,44 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 			g->drawHLine(px + 1, location.x + size.width, py+2);
 			break;
 		}
+	}
+	
+	// --------------------- draw moved selection ---------------------
+	
+	if (hasValidSelection() && moveSelection)
+	{
+		pp_int32 moveSelectionRows = moveSelectionFinalPos.row - moveSelectionInitialPos.row;
+		pp_int32 moveSelectionChannels = moveSelectionFinalPos.channel - moveSelectionInitialPos.channel;
+		
+		pp_int32 i1 = selectionStart.row + moveSelectionRows;
+		pp_int32 j1 = selectionStart.channel + moveSelectionChannels;
+		pp_int32 i2 = selectionEnd.row + moveSelectionRows;
+		pp_int32 j2 = selectionEnd.channel + moveSelectionChannels;
+		
+		pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
+		pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);
+		
+		pp_int32 x2 = (location.x + (j2-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionEnd.inner]+cursorSizes[selectionEnd.inner] + (getRowCountWidth() + 3);
+		pp_int32 y2 = (location.y + (i2-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight()*2 + 2);
+		
+		if (::getKeyModifier() & selectionKeyModifier)
+			g->setColor(hiLightPrimary);   // for cloning the selection instead of moving it
+		else
+			g->setColor(textColor);
+		
+		const pp_int32 dashLen = 6;
+		
+		// inner dashed lines
+		g->drawHLineDashed(x1, x2, y1, dashLen, 3);
+		g->drawHLineDashed(x1, x2, y2, dashLen, 3);
+		g->drawVLineDashed(y1, y2, x1, dashLen, 3);
+		g->drawVLineDashed(y1, y2+1, x2, dashLen, 3);
+		
+		// outer dashed lines
+		g->drawHLineDashed(x1-1, x2+1, y1-1, dashLen, 1);
+		g->drawHLineDashed(x1-1, x2+1, y2+1, dashLen, 3);
+		g->drawVLineDashed(y1-1, y2+1, x1-1, dashLen, 1);
+		g->drawVLineDashed(y1-1, y2+2, x2+1, dashLen, 3);
 	}
 	
 	// draw scrollbars

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -732,6 +732,34 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 			g->drawString(name,px, py);
 		}
 	}
+	
+	
+	// --------------------- draw moved selection ---------------------
+
+	if (hasValidSelection() && moveSelection)
+	{
+		// location -- screen position of the top-left corner of the pattern editor window
+		pp_int32 moveSelectionRows = moveSelectionFinalPos.row - moveSelectionInitialPos.row;
+		pp_int32 moveSelectionChannels = moveSelectionFinalPos.channel - moveSelectionInitialPos.channel;
+		
+		pp_int32 i1 = selectionStart.row + moveSelectionRows;
+		pp_int32 j1 = selectionStart.channel + moveSelectionChannels;
+		pp_int32 i2 = selectionEnd.row + moveSelectionRows;
+		pp_int32 j2 = selectionEnd.channel + moveSelectionChannels;
+		
+		pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
+		pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);
+		
+		pp_int32 x2 = (location.x + (j2-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionEnd.inner]+cursorSizes[selectionEnd.inner] + (getRowCountWidth() + 3);
+		pp_int32 y2 = (location.y + (i2-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight()*2 + 4);
+		
+		g->setColor(textColor);
+		g->drawHLine(x1, x2, y1);
+		g->drawHLine(x1, x2, y2);
+		g->drawVLine(y1, y2, x1);
+		g->drawVLine(y1, y2 + 1, x2);
+		
+	}
 
 	for (j = startPos; j < numVisibleChannels; j++)
 	{

--- a/src/tracker/PatternEditorControl.cpp
+++ b/src/tracker/PatternEditorControl.cpp
@@ -22,6 +22,7 @@
 
 #include "PatternEditorControl.h"
 #include "GraphicsAbstract.h"
+#include "Tools.h"
 #include "Screen.h"
 #include "Control.h"
 #include "Font.h"
@@ -828,14 +829,10 @@ void PatternEditorControl::paint(PPGraphicsAbstract* g)
 		
 		if (i2 >= 0 && j2 >= 0 && i1 < pattern->rows && j1 < numVisibleChannels)
 		{
-			#define CLAMP(a, min, max) ((a) < (min) ? (min) : ((a) >= (max) ? (max-1) : (a)))
-			
-			i1 = CLAMP(i1, 0, pattern->rows);
-			i2 = CLAMP(i2, 0, pattern->rows);
-			j1 = CLAMP(j1, 0, numVisibleChannels);
-			j2 = CLAMP(j2, 0, numVisibleChannels);
-			
-			#undef CLAMP
+			i1 = PPTools::clamp(i1, 0, pattern->rows);
+			i2 = PPTools::clamp(i2, 0, pattern->rows);
+			j1 = PPTools::clamp(j1, 0, numVisibleChannels);
+			j2 = PPTools::clamp(j2, 0, numVisibleChannels);
 			
 			pp_int32 x1 = (location.x + (j1-startPos) * slotSize + SCROLLBARWIDTH) + cursorPositions[selectionStart.inner] + (getRowCountWidth() + 4);
 			pp_int32 y1 = (location.y + (i1-startIndex) * font->getCharHeight() + SCROLLBARWIDTH) + (font->getCharHeight() + 4);

--- a/src/tracker/PatternEditorControl.h
+++ b/src/tracker/PatternEditorControl.h
@@ -170,6 +170,10 @@ private:
 	pp_int32 selectionTicker;
 
 	bool hasDragged;
+	
+	bool moveSelection;
+	PatternEditorTools::Position moveSelectionInitialPos;
+	PatternEditorTools::Position moveSelectionFinalPos;
 
 	// edit menu
 	pp_int32 menuPosX;

--- a/src/tracker/PatternEditorControl.h
+++ b/src/tracker/PatternEditorControl.h
@@ -381,6 +381,9 @@ private:
 	void handleKeyChar(pp_uint8 character);
 	void handleKeyDown(pp_uint16 keyCode, pp_uint16 scanCode, pp_uint16 character);
 
+	void selectionModifierKeyDown();
+	void selectionModifierKeyUp();
+
 	// mark channel
 	void markChannel(pp_int32 channel, bool invert = true);
 	

--- a/src/tracker/PatternEditorControlEventListener.cpp
+++ b/src/tracker/PatternEditorControlEventListener.cpp
@@ -447,15 +447,14 @@ unmuteAll:
 				pp_int32 moveSelectionRows = moveSelectionFinalPos.row - moveSelectionInitialPos.row;
 				pp_int32 moveSelectionChannels = moveSelectionFinalPos.channel - moveSelectionInitialPos.channel;
 				
-				if (::getKeyModifier() & selectionKeyModifier)
-					patternEditor->cloneSelection(moveSelectionChannels, moveSelectionRows);
-				else
-					patternEditor->moveSelection(moveSelectionChannels, moveSelectionRows);
-				
-				// TODO: clamp to prevent pasting out of bounds
-				
-				
-			}	
+				if (patternEditor->canMoveSelection(moveSelectionChannels, moveSelectionRows))
+				{
+					if (::getKeyModifier() & selectionKeyModifier)
+						patternEditor->cloneSelection(moveSelectionChannels, moveSelectionRows);
+					else
+						patternEditor->moveSelection(moveSelectionChannels, moveSelectionRows);
+				}
+			}
 			else if (!hasDragged && !(::getKeyModifier() & selectionKeyModifier) && ppreCursor)
 			{
 				if (properties.clickToCursor)

--- a/src/tracker/PatternEditorTools.cpp
+++ b/src/tracker/PatternEditorTools.cpp
@@ -1718,6 +1718,40 @@ void PatternEditorTools::normalize()
 	
 }
 
+bool PatternEditorTools::selectionContains(const TXMPattern* pattern, const Position& ss, const Position& se, const Position& pos)
+{
+	pp_int32 selectionStartChannel;
+	pp_int32 selectionStartRow;
+	pp_int32 selectionStartInner;
+	pp_int32 selectionEndChannel;
+	pp_int32 selectionEndRow;
+	pp_int32 selectionEndInner;
+	
+	if (!normalizeSelection(pattern, ss, se, 
+							selectionStartChannel, selectionStartRow, selectionStartInner,
+							selectionEndChannel, selectionEndRow,selectionEndInner))
+		return false;
+	
+	// only entire instrument column is allowed
+	if (selectionStartInner >= 1 && selectionStartInner<=2)
+		selectionStartInner = 1;
+	if (selectionEndInner >= 1 && selectionEndInner<=2)
+		selectionEndInner = 2;
+	// only entire volume column can be selected
+	if (selectionStartInner >= 3 && selectionStartInner<=4)
+		selectionStartInner = 3;
+	if (selectionEndInner >= 3 && selectionEndInner<=4)
+		selectionEndInner = 4;
+	
+	bool outside =
+		pos.row < selectionStartRow || pos.row > selectionEndRow ||
+		pos.channel < selectionStartChannel || pos.channel > selectionEndChannel ||
+		(pos.channel == selectionStartChannel && pos.inner < selectionStartInner) ||
+		(pos.channel == selectionEndChannel && pos.inner > selectionEndInner);
+	
+	return !outside;
+}
+
 bool PatternEditorTools::hasValidSelection(const TXMPattern* pattern, const Position& ss, const Position& se, pp_int32 numVisibleChannels/* = -1*/)
 {
 	if (pattern == NULL || pattern->patternData == NULL)
@@ -1888,4 +1922,111 @@ void PatternEditorTools::slotClear(mp_ubyte* dst, pp_int32 from, pp_int32 to)
 	i++;
 }
 
+bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, pp_int32 moveChannels, pp_int32 moveRows, bool clear)
+{
+	if (!PatternEditorTools::hasValidSelection(pattern, ss, se))
+		return 0;
 
+	pp_int32 selectionStartChannel;
+	pp_int32 selectionStartRow;
+	pp_int32 selectionStartInner;
+	pp_int32 selectionEndChannel;
+	pp_int32 selectionEndRow;
+	pp_int32 selectionEndInner;
+
+	if (!normalizeSelection(pattern, ss, se, 
+							selectionStartChannel, selectionStartRow, selectionStartInner,
+							selectionEndChannel, selectionEndRow,selectionEndInner))
+		return 0;
+	
+	// only entire instrument column is allowed
+	if (selectionStartInner >= 1 && selectionStartInner<=2)
+		selectionStartInner = 1;
+	if (selectionEndInner >= 1 && selectionEndInner<=2)
+		selectionEndInner = 2;
+	// only entire volume column can be selected
+	if (selectionStartInner >= 3 && selectionStartInner<=4)
+		selectionStartInner = 3;
+	if (selectionEndInner >= 3 && selectionEndInner<=4)
+		selectionEndInner = 4;
+	
+	pp_int32 selectionWidth = selectionEndChannel - selectionStartChannel + 1;
+	pp_int32 selectionHeight = selectionEndRow - selectionStartRow + 1;
+	
+	mp_sint32 slotSize = pattern->effnum * 2 + 2;
+	ASSERT(slotSize == 6);
+	
+	mp_sint32 rowSizeDst = slotSize*selectionWidth;
+	mp_sint32 rowSizeSrc = slotSize*pattern->channum;
+	mp_sint32 bufferSize = selectionHeight * rowSizeDst;
+	
+	mp_ubyte* buffer = new mp_ubyte[bufferSize];
+	
+	if (buffer == NULL)
+		return 0;
+	
+	memset(buffer, 0, bufferSize);
+	
+	// copy to temporary buffer, erase source if desired
+	
+	for (pp_int32 i = 0; i < selectionHeight; i++)
+	{
+		for (pp_int32 j = 0; j < selectionWidth; j++)
+		{
+			mp_ubyte* src = pattern->patternData + (selectionStartRow+i)*rowSizeSrc+(selectionStartChannel+j)*slotSize;
+			mp_ubyte* dst = buffer + i*rowSizeDst+j*slotSize;
+		
+			if (selectionWidth == 1)
+			{
+				PatternEditorTools::slotCopy(dst, src, selectionStartInner, selectionEndInner);
+				if (clear)
+					PatternEditorTools::slotClear(src, selectionStartInner, selectionEndInner);
+			}
+			else if (j == 0)
+			{
+				PatternEditorTools::slotCopy(dst, src, selectionStartInner, 7);
+				if (clear)
+					PatternEditorTools::slotClear(src, selectionStartInner, 7);
+			}
+			else if (j+selectionStartChannel == selectionEndChannel)
+			{
+				PatternEditorTools::slotCopy(dst, src, 0, selectionEndInner);
+				if (clear)
+					PatternEditorTools::slotClear(src, 0, selectionEndInner);
+			}
+			else
+			{
+				PatternEditorTools::slotCopy(dst, src, 0, 7);
+				if (clear)
+					PatternEditorTools::slotClear(src, 0, 7);
+			}
+		}
+	}
+	
+	// destination position
+	pp_int32 offsetStartChannel = selectionStartChannel + moveChannels;
+	pp_int32 offsetStartRow = selectionStartRow + moveRows;
+	
+	// paste from temporary buffer to target location
+	for (pp_int32 i = 0; i < selectionHeight; i++)
+	{
+		for (pp_int32 j = 0; j < selectionWidth; j++)
+		{
+			mp_ubyte* src = buffer + i*rowSizeDst+j*slotSize;
+			mp_ubyte* dst = pattern->patternData + (offsetStartRow+i)*rowSizeSrc+(offsetStartChannel+j)*slotSize;
+			
+			if (selectionWidth == 1)
+				PatternEditorTools::slotCopy(dst, src, selectionStartInner, selectionEndInner);
+			else if (j == 0)
+				PatternEditorTools::slotCopy(dst, src, selectionStartInner, 7);
+			else if (j+selectionStartChannel == selectionEndChannel)
+				PatternEditorTools::slotCopy(dst, src, 0, selectionEndInner);
+			else
+				PatternEditorTools::slotCopy(dst, src, 0, 7);
+		}
+	}
+	
+	delete[] buffer;
+	
+	return 1;
+}

--- a/src/tracker/PatternEditorTools.cpp
+++ b/src/tracker/PatternEditorTools.cpp
@@ -1924,16 +1924,25 @@ void PatternEditorTools::slotClear(mp_ubyte* dst, pp_int32 from, pp_int32 to)
 
 bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, pp_int32 moveChannels, pp_int32 moveRows, bool clear)
 {
+	Position targetStart = ss;
+	Position targetEnd = se;
+	targetStart.channel += moveChannels;
+	targetStart.row += moveRows;
+	targetEnd.channel += moveChannels;
+	targetEnd.row += moveRows;
+	
 	if (!PatternEditorTools::hasValidSelection(pattern, ss, se))
 		return 0;
-
+	if (!PatternEditorTools::hasValidSelection(pattern, targetStart, targetEnd))
+		return 0;
+	
 	pp_int32 selectionStartChannel;
 	pp_int32 selectionStartRow;
 	pp_int32 selectionStartInner;
 	pp_int32 selectionEndChannel;
 	pp_int32 selectionEndRow;
 	pp_int32 selectionEndInner;
-
+	
 	if (!normalizeSelection(pattern, ss, se, 
 							selectionStartChannel, selectionStartRow, selectionStartInner,
 							selectionEndChannel, selectionEndRow,selectionEndInner))

--- a/src/tracker/PatternEditorTools.cpp
+++ b/src/tracker/PatternEditorTools.cpp
@@ -1774,12 +1774,14 @@ void PatternEditorTools::slotCopy(mp_ubyte* dst, mp_ubyte* src, pp_int32 from, p
 {
 	pp_int32 i = 0;
 	
+	// copy note
 	if (i >= from && i <= to)
 	{
 		*dst = *src;
 	}
 	i++;
-		
+	
+	// copy instrument first digit
 	if (i >= from && i <= to)
 	{
 		*(dst+1) &= 0x0F;
@@ -1787,26 +1789,30 @@ void PatternEditorTools::slotCopy(mp_ubyte* dst, mp_ubyte* src, pp_int32 from, p
 	}
 	i++;
 	
+	// copy instrument second digit
 	if (i >= from && i <= to)
 	{
 		*(dst+1) &= 0xF0;
 		*(dst+1) |= *(src+1)&0xF;		
 	}
 	i++;
-
+	
+	// copy volume
 	if (i >= from && i <= to)
 	{
 		*(dst+2) = *(src+2);
 		*(dst+3) = *(src+3);
 	}
 	i+=2;
-
+	
+	// copy effect type
 	if (i >= from && i <= to)
 	{
 		*(dst+4) = *(src+4);
 	}
 	i++;
-
+	
+	// copy effect parameter first digit
 	if (i >= from && i <= to)
 	{
 		*(dst+5) &= 0x0F;
@@ -1814,24 +1820,33 @@ void PatternEditorTools::slotCopy(mp_ubyte* dst, mp_ubyte* src, pp_int32 from, p
 	}
 	i++;
 	
+	// copy effect parameter second digit
 	if (i >= from && i <= to)
 	{
 		*(dst+5) &= 0xF0;
 		*(dst+5) |= *(src+5)&0xF;		
 	}
 	i++;
+	
+	// special cases for arpeggio effect:
+	if (*(dst+4) == 0x20 && *(dst+5) == 0)
+		*(dst+4) = 0;
+	else if (*(dst+4) == 0 && *(dst+5) != 0)
+		*(dst+4) = 0x20;
 }
 
 void PatternEditorTools::slotTransparentCopy(mp_ubyte* dst, mp_ubyte* src, pp_int32 from, pp_int32 to)
 {
 	pp_int32 i = 0;
 	
+	// copy note
 	if (i >= from && i <= to && *src)
 	{
 		*dst = *src;
 	}
 	i++;
-		
+	
+	// copy instrument first digit
 	if (i >= from && i <= to && (*(src+1)&0xF0))
 	{
 		*(dst+1) &= 0x0F;
@@ -1839,26 +1854,30 @@ void PatternEditorTools::slotTransparentCopy(mp_ubyte* dst, mp_ubyte* src, pp_in
 	}
 	i++;
 	
+	// copy instrument second digit
 	if (i >= from && i <= to && (*(src+1)&0xF))
 	{
 		*(dst+1) &= 0xF0;
 		*(dst+1) |= *(src+1)&0xF;		
 	}
 	i++;
-
+	
+	// copy volume
 	if (i >= from && i <= to && (*(src+2) || *(src+3)))
 	{
 		*(dst+2) = *(src+2);
 		*(dst+3) = *(src+3);
 	}
 	i+=2;
-
+	
+	// copy effect type
 	if (i >= from && i <= to && (*(src+4)))
 	{
 		*(dst+4) = *(src+4);
 	}
 	i++;
-
+	
+	// copy effect parameter first digit
 	if (i >= from && i <= to && (*(src+5)&0xF0))
 	{
 		*(dst+5) &= 0x0F;
@@ -1866,60 +1885,80 @@ void PatternEditorTools::slotTransparentCopy(mp_ubyte* dst, mp_ubyte* src, pp_in
 	}
 	i++;
 	
+	// copy effect parameter second digit
 	if (i >= from && i <= to && (*(src+5)&0xF))
 	{
 		*(dst+5) &= 0xF0;
 		*(dst+5) |= *(src+5)&0xF;		
 	}
 	i++;
+	
+	// special cases for arpeggio effect:
+	if (*(dst+4) == 0x20 && *(dst+5) == 0)
+		*(dst+4) = 0;
+	else if (*(dst+4) == 0 && *(dst+5) != 0)
+		*(dst+4) = 0x20;
 }
 
 void PatternEditorTools::slotClear(mp_ubyte* dst, pp_int32 from, pp_int32 to)
 {
 	pp_int32 i = 0;
 	
+	// clear note
 	if (i >= from && i <= to)
 	{
 		*dst = 0;
 	}
 	i++;
-		
+	
+	// clear instrument first digit
 	if (i >= from && i <= to)
 	{
 		*(dst+1) &= 0x0F;
 	}
 	i++;
 	
+	// clear instrument second digit
 	if (i >= from && i <= to)
 	{
 		*(dst+1) &= 0xF0;
 	}
 	i++;
 
+	// clear volume
 	if (i >= from && i <= to)
 	{
 		*(dst+2) = 0;
 		*(dst+3) = 0;
 	}
 	i+=2;
-
+	
+	// clear effect type
 	if (i >= from && i <= to)
 	{
 		*(dst+4) = 0;
 	}
 	i++;
-
+	
+	// clear effect parameter first digit
 	if (i >= from && i <= to)
 	{
 		*(dst+5) &= 0x0F;
 	}
 	i++;
 	
+	// clear effect parameter second digit
 	if (i >= from && i <= to)
 	{
 		*(dst+5) &= 0xF0;
 	}
 	i++;
+	
+	// special cases for arpeggio effect:
+	if (*(dst+4) == 0x20 && *(dst+5) == 0)
+		*(dst+4) = 0;
+	else if (*(dst+4) == 0 && *(dst+5) != 0)
+		*(dst+4) = 0x20;
 }
 
 bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, pp_int32 moveChannels, pp_int32 moveRows, bool clear)

--- a/src/tracker/PatternEditorTools.cpp
+++ b/src/tracker/PatternEditorTools.cpp
@@ -1980,10 +1980,20 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	
 	for (pp_int32 i = 0; i < selectionHeight; i++)
 	{
+		pp_int32 rowSrc = selectionStartRow + i;
+		
+		if (rowSrc < 0 || rowSrc >= pattern->rows)
+			continue;
+		
 		for (pp_int32 j = 0; j < selectionWidth; j++)
 		{
-			mp_ubyte* src = pattern->patternData + (selectionStartRow+i)*rowSizeSrc+(selectionStartChannel+j)*slotSize;
-			mp_ubyte* dst = buffer + i*rowSizeDst+j*slotSize;
+			pp_int32 channelSrc = selectionStartChannel + j;
+			
+			if (channelSrc < 0 || channelSrc >= pattern->channum)
+				continue;
+			
+			mp_ubyte* src = pattern->patternData + rowSrc*rowSizeSrc + channelSrc*slotSize;
+			mp_ubyte* dst = buffer + i*rowSizeDst + j*slotSize;
 		
 			if (selectionWidth == 1)
 			{
@@ -2019,10 +2029,20 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	// paste from temporary buffer to target location
 	for (pp_int32 i = 0; i < selectionHeight; i++)
 	{
+		pp_int32 rowDst = offsetStartRow + i;
+		
+		if (rowDst < 0 || rowDst >= pattern->rows)
+			continue;
+		
 		for (pp_int32 j = 0; j < selectionWidth; j++)
 		{
-			mp_ubyte* src = buffer + i*rowSizeDst+j*slotSize;
-			mp_ubyte* dst = pattern->patternData + (offsetStartRow+i)*rowSizeSrc+(offsetStartChannel+j)*slotSize;
+			pp_int32 channelDst = offsetStartChannel + j;
+			
+			if (channelDst < 0 || channelDst >= pattern->channum)
+				continue;
+			
+			mp_ubyte* src = buffer + i*rowSizeDst + j*slotSize;
+			mp_ubyte* dst = pattern->patternData + rowDst*rowSizeSrc + channelDst*slotSize;
 			
 			if (selectionWidth == 1)
 				PatternEditorTools::slotCopy(dst, src, selectionStartInner, selectionEndInner);

--- a/src/tracker/PatternEditorTools.cpp
+++ b/src/tracker/PatternEditorTools.cpp
@@ -155,14 +155,14 @@ void PatternEditorTools::clearSelection(const PatternEditorTools::Position& ss, 
 		return;
 		
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 		
 	pp_int32 selectionWidth = selectionEndChannel - selectionStartChannel + 1;
@@ -393,14 +393,14 @@ pp_int32 PatternEditorTools::insRemapSelection(const Position& ss, const Positio
 		return 0;
 		
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 		
 	pp_int32 selectionWidth = selectionEndChannel - selectionStartChannel + 1;
@@ -496,14 +496,14 @@ pp_int32 PatternEditorTools::noteTransposeSelection(const Position& ss, const Po
 		return 0;
 		
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 		
 	pp_int32 selectionWidth = selectionEndChannel - selectionStartChannel + 1;
@@ -624,14 +624,14 @@ pp_int32 PatternEditorTools::interpolateValuesInSelection(const PatternEditorToo
 		return 0;
 
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 	// only entire effect operand column
 	if (selectionStartInner >= 6 && selectionStartInner<=7)
@@ -1733,14 +1733,14 @@ bool PatternEditorTools::selectionContains(const TXMPattern* pattern, const Posi
 		return false;
 	
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 	
 	bool outside =
@@ -1971,9 +1971,9 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	targetEnd.row += moveRows;
 	
 	if (!PatternEditorTools::hasValidSelection(pattern, ss, se))
-		return 0;
+		return false;
 	if (!PatternEditorTools::hasValidSelection(pattern, targetStart, targetEnd))
-		return 0;
+		return false;
 	
 	pp_int32 selectionStartChannel;
 	pp_int32 selectionStartRow;
@@ -1985,23 +1985,25 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	if (!normalizeSelection(pattern, ss, se, 
 							selectionStartChannel, selectionStartRow, selectionStartInner,
 							selectionEndChannel, selectionEndRow,selectionEndInner))
-		return 0;
+		return false;
 	
 	// only entire instrument column is allowed
-	if (selectionStartInner >= 1 && selectionStartInner<=2)
+	if (selectionStartInner >= 1 && selectionStartInner <= 2)
 		selectionStartInner = 1;
-	if (selectionEndInner >= 1 && selectionEndInner<=2)
+	if (selectionEndInner >= 1 && selectionEndInner <= 2)
 		selectionEndInner = 2;
 	// only entire volume column can be selected
-	if (selectionStartInner >= 3 && selectionStartInner<=4)
+	if (selectionStartInner >= 3 && selectionStartInner <= 4)
 		selectionStartInner = 3;
-	if (selectionEndInner >= 3 && selectionEndInner<=4)
+	if (selectionEndInner >= 3 && selectionEndInner <= 4)
 		selectionEndInner = 4;
 	
 	pp_int32 selectionWidth = selectionEndChannel - selectionStartChannel + 1;
 	pp_int32 selectionHeight = selectionEndRow - selectionStartRow + 1;
 	
 	mp_sint32 slotSize = pattern->effnum * 2 + 2;
+	
+	// sanity check: only operate on internal XM pattern data
 	ASSERT(slotSize == 6);
 	
 	mp_sint32 rowSizeDst = slotSize*selectionWidth;
@@ -2011,7 +2013,7 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	mp_ubyte* buffer = new mp_ubyte[bufferSize];
 	
 	if (buffer == NULL)
-		return 0;
+		return false;
 	
 	memset(buffer, 0, bufferSize);
 	
@@ -2096,5 +2098,5 @@ bool PatternEditorTools::moveSelection(const Position& ss, const Position& se, p
 	
 	delete[] buffer;
 	
-	return 1;
+	return true;
 }

--- a/src/tracker/PatternEditorTools.h
+++ b/src/tracker/PatternEditorTools.h
@@ -158,6 +158,7 @@ public:
 	void attachPattern(TXMPattern* pattern) { this->pattern = pattern; }
 
 	void clearSelection(const Position& ss, const Position& se);
+	bool moveSelection(const Position& ss, const Position& se, pp_int32 moveChannels, pp_int32 moveRows, bool clear);
 	bool expandPattern();
 	bool shrinkPattern();
 
@@ -200,6 +201,7 @@ public:
 	static void slotTransparentCopy(mp_ubyte* dst, mp_ubyte* src, pp_int32 from, pp_int32 to);
 	static void slotClear(mp_ubyte* dst, pp_int32 from, pp_int32 to);
 
+	static bool selectionContains(const TXMPattern* pattern, const Position& ss, const Position& se, const Position& pos);
 	static bool hasValidSelection(const TXMPattern* pattern, const Position& ss, const Position& se, pp_int32 numVisibleChannels = -1);
 
 	static bool normalizeSelection(const TXMPattern* pattern, 


### PR DESCRIPTION
Hi! I've been working on a feature that I couldn't live without (after using Renoise for 6 years), I hope you like it!

![GIF 2020-05-03 02-30-05](https://user-images.githubusercontent.com/569607/80896826-6ef4e300-8cea-11ea-95f3-7920d880f42e.gif)

Summary of changes:
- Click and drag a selection in the pattern editor to move the selected pattern data
  - Use the modifier key to clone instead of moving
- More intuitive behaviour for cut/paste in the effect column
  - When cutting an effect type, the parameter value is preserved
  - When pasting an effect parameter value into an empty slot, the effect type will be set to Arpeggio (previously the effect would remain as "No Effect" so the value would not be pasted)
- Improved mouse handling near the edges of the pattern (selection is clamped to boundaries instead of ignoring input)
- Added MSYS2 + MinGW support to the CMake configuration
