### PR TITLE
Use previous implementation of fill_dword, minus asm

### DIFF
--- a/src/ppui/fastfill.h
+++ b/src/ppui/fastfill.h
@@ -30,26 +30,8 @@
 
 static inline void fill_dword(pp_uint32* buff, pp_uint32 dw, pp_uint32 len)
 {
-	pp_uint32 newlen = len >> 2;
-	pp_uint32 remlen = len & 3;
-	if (newlen)
-	{
-		do
-		{
-			*buff = dw;
-			*(buff+1) = dw;
-			*(buff+2) = dw;
-			*(buff+3) = dw;
-			buff += 4;
-		} while (--newlen);
-	}
-	if (remlen)
-	{
-		do
-		{
-			*buff++ = dw;
-		} while (--remlen);
-	}
+	while (len--)
+		*(buff++) = dw;
 }
 
 static inline void fill_dword_vertical(pp_uint32* buff, pp_uint32 dw, pp_uint32 len, pp_uint32 pitch)

--- a/src/ppui/fastfill.h
+++ b/src/ppui/fastfill.h
@@ -28,11 +28,28 @@
  *
  */
 
-#include <string.h>
-
 static inline void fill_dword(pp_uint32* buff, pp_uint32 dw, pp_uint32 len)
 {
-	memset(buff, dw, len);
+	pp_uint32 newlen = len >> 2;
+	pp_uint32 remlen = len & 3;
+	if (newlen)
+	{
+		do
+		{
+			*buff = dw;
+			*(buff+1) = dw;
+			*(buff+2) = dw;
+			*(buff+3) = dw;
+			buff += 4;
+		} while (--newlen);
+	}
+	if (remlen)
+	{
+		do
+		{
+			*buff++ = dw;
+		} while (--remlen);
+	}
 }
 
 static inline void fill_dword_vertical(pp_uint32* buff, pp_uint32 dw, pp_uint32 len, pp_uint32 pitch)


### PR DESCRIPTION
The new implementation of fill_dword completely messed up the UI, because memset only fills a byte value, not a 32-bit value

The simplest implementation would be
```cpp
while (len--)
    *(buff++) = dw;
```

But I went with the old implementation because I like it more, assuming that the compiler isn't gonna do some galaxy-brain optimisations to transform the above code into some even better bulk copy.