### PR TITLE
Fix windows build for non-MFC

### DIFF
--- a/src/tracker/win32/Win32_resources.rc
+++ b/src/tracker/win32/Win32_resources.rc
@@ -7,7 +7,11 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
+
+#ifndef IDC_STATIC
+#define IDC_STATIC              -1
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
See https://stackoverflow.com/q/3566018/2038264 and https://stackoverflow.com/q/37913963/2038264
`afxres.h` is an MFC header, which can be replaced with `windows.h` if the user doesn't have MFC.