### PR TITLE
easily 'sample' current pattern into current sample

### DIFF
--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -681,6 +681,9 @@
 			<tr class="odd">
 				<td><em>Ctrl-V</em></td><td>Paste</td>
 			</tr>
+			<tr class="odd">
+				<td><em>Ctrl-Shift-V</em></td><td>Convert current pattern to sample</td>
+			</tr>	
 			<tr class="even">
 				<td><em>Ctrl-I</em></td><td>Interpolate values</td>
 			</tr>

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -68,7 +68,7 @@
 				vertical-align: top;
 			}
 
-			tr.odd {
+			tr:nth-child(odd) {
 				background-color: #eee;
  			}
 
@@ -299,97 +299,97 @@
 		</p>
 		<h4>Import:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>.669</em></td><td>669 Composer/Unis669 (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td rowspan="2"><em>.AMF</em></td><td>Asylum Music Format ("Crusader" in-game music) (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td>Digital Sound and Music Interface (DSMI) library (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td rowspan="2"><em>.AMS</em></td><td>Extreme Tracker (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td>Velvet Studio (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.CBA</em></td><td>Chuck Biscuits+Black Artist module format (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.DBM</em></td><td>DigiBooster Pro (Amiga)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.DIGI</em></td><td>Digibooster 1.0-1.7 (Amiga)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td rowspan="2"><em>.DSM</em></td><td>Digisound Interface Kit (DSIK) library (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td>Dynamic Studio (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td rowspan="2"><em>.DTM</em></td><td>Digital Tracker (Atari)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td>DigiTrekker 3.0 (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.FAR</em></td><td>Farandole Composer (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.GDM</em></td><td>General Digimusic (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.GMC</em></td><td>Game Music Creator (Amiga)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.IMF</em></td><td>Imago Orpheus (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.IT</em></td><td>Impulse Tracker (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.MDL</em></td><td>DigiTrakker 1.0-3.0 (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.MOD</em></td><td>Sound-/ProTracker and variants (Amiga &amp; PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.MTM</em></td><td>MultiTracker (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.MXM</em></td><td>Cubic Tiny XM (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.OKT</em></td><td>Oktalyzer (Amiga)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.PLM</em></td><td>DisorderTracker II (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.PSM</em></td><td>Epic MegaGames MASI (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.PTM</em></td><td>PolyTracker (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.S3M</em></td><td>Scream Tracker 3.0 (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.SFX</em></td><td>SoundFX (Amiga)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.STM</em></td><td>Scream Tracker 2.0 (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.ULT</em></td><td>UltraTracker (PC)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.UNI</em></td><td>MikMod (PC)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.XM</em></td><td>Fasttracker II (PC)</td>
 			</tr>
 		</table>
@@ -398,13 +398,13 @@
 		</p>
 		<h4>Export:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>.MOD</em></td><td>ProTracker boundaries (including 64kb max sample length), although can save 2&ndash;32 channels</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.WAV</em></td><td>Microsoft/IBM PCM Waveform audio rendering</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.XM</em></td><td>Fasttracker II compatible, not as common as one might think</td>
 			</tr>
 		</table>
@@ -417,25 +417,25 @@
 		</p>
 		<h4>Import:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>.8SVX</em> / <em>.IFF</em></td><td>Compressed/uncompressed Interchange File Format</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.AIF</em> / <em>.AIFF</em></td><td>Apple Audio Interchange File Format</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>.WAV</em></td><td>Microsoft/IBM uncompressed PCM Waveform audio</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.*</em></td><td>RAW PCM audio</td>
 			</tr>
 		</table>
 		<h4>Export:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>.IFF</em></td><td>Uncompressed Interchange File Format</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>.WAV</em></td><td>Microsoft/IBM uncompressed PCM Waveform audio</td>
 			</tr>
 		</table>
@@ -467,43 +467,43 @@
 			<em>Please note that under Mac OS X the Command key is used instead of the Ctrl key.</em>
 		</p>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-Enter</em></td><td>Switch between full screen and windowed display (Windows &amp; SDL)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Command-F</em></td><td>Switch between full screen and windowed display (OS X)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-M</em></td><td>Mute current channel</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-M</em></td><td>Invert muting</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-U</em></td><td>Un-mute all</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-T</em></td><td>Open a new tab</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Shift-W</em></td><td>Close current tab</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-Left</em></td><td>Select previous tab</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Shift-Right</em></td><td>Select next tab</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-=</em></td><td>Increment instrument number of all notes in the current selection</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl--</em></td><td>Decrement instrument number of all notes in the current selection</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Shift-=</em></td><td>Increment instrument number of all notes in the current track under the cursor</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Shift--</em></td><td>Decrement instrument number of all notes in the current track under the cursor</td>
 			</tr>
 		</table>
@@ -513,274 +513,309 @@
 		</p>
 		<h4>Section switching:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td colspan="2"><em>Ctrl-Alt-</em></td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>A</em></td><td>Advanced edit</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>C</em></td><td>Configuration</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>D</em></td><td>Disk operations</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>I</em></td><td>Instrument editor</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>R</em></td><td>Disk recorder</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>S</em></td><td>Sample editor</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>T</em></td><td>Transpose</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>X</em></td><td>Main screen</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Z</em></td><td>Toggle scopes</td>
 			</tr>
 		</table>
 		<h4>Global:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>2, 3, 5, 6&hellip;</em></td><td rowspan="4" style="vertical-align: middle;">Play / insert notes (depending on whether edit mode is on)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Q, W, E, R&hellip;</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>S, D, F, G&hellip;</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Z, X, C, V&hellip;</em></td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>F1&hellip;F8</em></td><td rowspan="2">Select octave</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-1&hellip;8</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Space</em></td><td>Toggle pattern editor focus (edit mode on/off)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Enter</em></td><td>Play song from current order</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Enter</em></td><td>Play current pattern from beginning</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Enter</em></td><td>Play current pattern from cursor position</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F9</em></td><td>Play current pattern from beginning (same as Ctrl-Enter)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F10</em></td><td>Play current pattern from position after the first quarter of the pattern length</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F11</em></td><td>Play current pattern from position after the second quarter of the pattern length</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F12</em></td><td>Play current pattern from position after the third quarter of the pattern length</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-Space</em></td><td>Play song from current row (stop and return when keys are released)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Space</em></td><td>Play row by row</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Esc</em></td><td>Stop</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F</em></td><td>Toggle song follow</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-P</em></td><td>Toggle prospective pattern view</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-W</em></td><td>Toggle pattern wrapping</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-L</em></td><td>Toggle pattern change behavior (live mode)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-O</em></td><td>Load song</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-S</em></td><td>Save song</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-S</em></td><td>Save song as&hellip;</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Q</em></td><td rowspan="2">Exit program</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F4</em></td>
 			</tr>
 		</table>
 		<h4>Pattern Editor:</h4>
 		<table>
-			<tr class="even">
-				<td><em>Cursor keys</em></td><td>Move around</td>
+			<tr >
+				<td><em>Cursor keys</em></td>
+				<td>Move around</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Tab</em></td><td>Jump to next channel</td>
+			<tr >
+				<td><em>Tab</em></td>
+				<td>Jump to next channel</td>
 			</tr>
-			<tr class="even">
-				<td><em>PageUp</em></td><td>Jump 16 rows up</td>
+			<tr >
+				<td><em>PageUp</em></td>
+				<td>Jump 16 rows up</td>
 			</tr>
-			<tr class="odd">
-				<td><em>PageDown</em></td><td>Jump 16 rows down</td>
+			<tr >
+				<td><em>PageDown</em></td>
+				<td>Jump 16 rows down</td>
 			</tr>
-			<tr class="even">
-				<td><em>Home</em></td><td>Jump to first row</td>
+			<tr >
+				<td><em>Home</em></td>
+				<td>Jump to first row</td>
 			</tr>
-			<tr class="odd">
-				<td><em>End</em></td><td>Jump to last row</td>
+			<tr >
+				<td><em>End</em></td>
+				<td>Jump to last row</td>
 			</tr>
-			<tr class="even">
-				<td><em>F9</em></td><td>Jump to beginning of the pattern</td>
+			<tr >
+				<td><em>F9</em></td>
+				<td>Jump to beginning of the pattern</td>
 			</tr>
-			<tr class="odd">
-				<td><em>F10</em></td><td>Jump to position &frac14; through the pattern</td>
+			<tr >
+				<td><em>F10</em></td>
+				<td>Jump to position &frac14; through the pattern</td>
 			</tr>
-			<tr class="even">
-				<td><em>F11</em></td><td>Jump to position halfway through the pattern</td>
+			<tr >
+				<td><em>F11</em></td>
+				<td>Jump to position halfway through the pattern</td>
 			</tr>
-			<tr class="odd">
-				<td><em>F12</em></td><td>Jump to position &frac34; through the pattern</td>
+			<tr >
+				<td><em>F12</em></td>
+				<td>Jump to position &frac34; through the pattern</td>
 			</tr>
-			<tr class="even">
-				<td><em>Ctrl-Z</em></td><td>Undo</td>
+			<tr >
+				<td><em>Ctrl-Z</em></td>
+				<td>Undo</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Ctrl-Y</em></td><td>Redo</td>
+			<tr >
+				<td><em>Ctrl-Y</em></td>
+				<td>Redo</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Cursor keys</em></td><td>Select block</td>
+			<tr >
+				<td><em>Shift-Cursor keys</em></td>
+				<td>Select block</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Shift-Alt-Cursor keys</em></td><td>Extend block</td>
+			<tr >
+				<td><em>Shift-Alt-Cursor keys</em></td>
+				<td>Extend block</td>
 			</tr>
-			<tr class="even">
-				<td><em>Ctrl-A</em></td><td>Select entire pattern</td>
+			<tr >
+				<td><em>Ctrl-A</em></td>
+				<td>Select entire pattern</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Ctrl-X</em></td><td>Cut</td>
+			<tr >
+				<td><em>Ctrl-X</em></td>
+				<td>Cut</td>
 			</tr>
-			<tr class="even">
-				<td><em>Ctrl-C</em></td><td>Copy</td>
+			<tr >
+				<td><em>Ctrl-C</em></td>
+				<td>Copy</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Ctrl-V</em></td><td>Paste</td>
+			<tr >
+				<td><em>Ctrl-V</em></td>
+				<td>Paste</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Ctrl-Shift-V</em></td><td>Convert current pattern to sample</td>
-			</tr>	
-			<tr class="even">
-				<td><em>Ctrl-I</em></td><td>Interpolate values</td>
+			<tr >
+				<td><em>Ctrl-Shift-V</em></td>
+				<td>Convert current pattern to sample</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Delete</em></td><td>Delete note/instrument/volume/effect/parameter</td>
+			<tr >
+				<td><em>Ctrl-I</em></td>
+				<td>Interpolate values</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Del</em></td><td>Delete note, volume and effect at cursor</td>
+			<tr >
+				<td><em>Delete</em></td>
+				<td>Delete note/instrument/volume/effect/parameter</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Ctrl-Del</em></td><td>Delete volume and effect at cursor</td>
+			<tr >
+				<td><em>Shift-Del</em></td>
+				<td>Delete note, volume and effect at cursor</td>
 			</tr>
-			<tr class="even">
-				<td><em>Alt-Delete</em></td><td>Delete effect at cursor</td>
+			<tr >
+				<td><em>Ctrl-Del</em></td>
+				<td>Delete volume and effect at cursor</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Insert</em></td><td>Insert space on current track at cursor position</td>
+			<tr >
+				<td><em>Alt-Delete</em></td>
+				<td>Delete effect at cursor</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Insert</em></td><td>Insert row at cursor position</td>
+			<tr >
+				<td><em>Insert</em></td>
+				<td>Insert space on current track at cursor position</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Alt-Backspace</em></td><td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
+			<tr >
+				<td><em>Shift-Insert</em></td>
+				<td>Insert row at cursor position</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Alt-Backspace</em></td><td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
+			<tr >
+				<td><em>Alt-Backspace</em></td>
+				<td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Backspace</em></td><td>Delete previous note</td>
+			<tr >
+				<td><em>Shift-Alt-Backspace</em></td>
+				<td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Backspace</em></td><td>Delete previous row</td>
+			<tr >
+				<td><em>Backspace</em></td>
+				<td>Delete previous note</td>
 			</tr>
-			<tr class="odd">
-				<td><em>The key right of LShift</em></td><td>Enter key-off</td>
+			<tr >
+				<td><em>Shift-Backspace</em></td>
+				<td>Delete previous row</td>
 			</tr>
-			<tr class="even">
-				<td><em>The key below Esc</em></td><td>Enter key-off (Windows only)</td>
+			<tr >
+				<td><em>The key right of LShift</em></td>
+				<td>Enter key-off</td>
 			</tr>
-			<tr class="odd">
-				<td><em>1</em></td><td>Enter key-off (OS X only)</td>
+			<tr >
+				<td><em>The key below Esc</em></td>
+				<td>Enter key-off (Windows only)</td>
 			</tr>
-            <tr class="even">
-				<td><em>Alt-Minus</em></td><td>Increase Add value</td>
+			<tr >
+				<td><em>1</em></td>
+				<td>Enter key-off (OS X only)</td>
 			</tr>
-			<tr class="odd">
-				<td><em>or Alt-Plus</em></td><td>Decrease Add value</td>
+			<tr >
+				<td><em>Alt-Minus</em></td>
+				<td>Increase Add value</td>
+			</tr>
+			<tr >
+				<td><em>or Alt-Plus</em></td>
+				<td>Decrease Add value</td>
 			</tr>
 		</table>
 		<h4>Transpose:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F7</em></td><td>Transpose current instrument in block down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F8</em></td><td>Transpose current instrument in block up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F7</em></td><td>Transpose current instrument in track down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F8</em></td><td>Transpose current instrument in track up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F7</em></td><td>Transpose current instrument in pattern down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F8</em></td><td>Transpose current instrument in pattern up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F1</em></td><td>Transpose all instruments in block down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F2</em></td><td>Transpose all instruments in block up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F1</em></td><td>Transpose all instruments in track down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F2</em></td><td>Transpose all instruments in track up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F1</em></td><td>Transpose all instruments in pattern down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F2</em></td><td>Transpose all instruments in pattern up</td>
 			</tr>
 		</table>
 		<h4>Sample Editor:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Shift &amp; drag</em></td><td>Quick draw</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl &amp; drag</em></td><td>Resize selection</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt &amp; drag</em></td><td>Move selection or loop range</td>
 			</tr>
 		</table>
@@ -793,142 +828,142 @@
 		</p>
 		<h4>Section switching:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td colspan="2"><em>Ctrl-</em></td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>A</em></td><td>Advanced edit</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>C</em></td><td>Configuration</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>D</em></td><td>Disk operations</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>I</em></td><td>Instrument editor</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>R</em></td><td>Disk recorder</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>S</em></td><td>Sample editor</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>T</em></td><td>Transpose</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>X</em></td><td>Main screen</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Z</em></td><td>Toggle scopes</td>
 			</tr>
 		</table>
 		<h4>Global:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>2, 3, 5, 6&hellip;</em></td><td rowspan="4" style="vertical-align: middle;">Play / insert notes (depending on whether edit mode is on)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Q, W, E, R&hellip;</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>S, D, F, G&hellip;</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Z, X, C, V&hellip;</em></td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>F1&hellip;F8</em></td><td>Select octave</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Right Ctrl</em></td><td>Play song from current order</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Enter</em></td><td>Play song from current order</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Right Alt</em></td><td>Play current pattern from beginning (Windows &amp;SDL)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Enter</em></td><td>Play current pattern from beginning</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Enter</em></td><td>Play current pattern from current row</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F9</em></td><td>Play current pattern from beginning (same as Ctrl-Enter/Right Alt)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F10</em></td><td>Play current pattern from position after the first quarter of the pattern length</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F11</em></td><td>Play current pattern from position after the second quarter of the pattern length</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F12</em></td><td>Play current pattern from position after the third quarter of the pattern length</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-Space</em></td><td>Play song from current row (stop and return when keys are released)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Space</em></td><td>Play row by row</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Space</em></td><td>Stop / Edit</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Left</em></td><td>Increase song position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Right</em></td><td>Decrease song position</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Left</em></td><td>Increase current pattern number</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Right</em></td><td>Decrease current pattern number</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F9</em></td><td>Delete current order position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F10</em></td><td>Insert new order position</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F11</em></td><td>Decrease
 				current order pattern number</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F12</em></td><td>Increase current order pattern number</td>
-			<tr class="even">
+			<tr >
 				<td><em>Key below ESC (ANSI: Alt-Minus)*</em></td><td>Increase Add value</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-key below ESC (ANSI: Alt-Plus)*</em></td><td>Decrease Add value</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F</em></td><td>Toggle song follow</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-P</em></td><td>Toggle prospective pattern view</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-W</em></td><td>Toggle pattern wrapping</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-L</em></td><td>Toggle pattern change behavior (live mode)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Ctrl-L</em></td><td>Load song</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-R</em></td><td>Toggle record mode</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Ctrl-S</em></td><td>Save song</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Esc</em></td><td>Exit program</td>
 			</tr>
 		</table>
@@ -937,217 +972,247 @@
 		</p>
 		<h4>Pattern editor:</h4>
 		<table>
-			<tr class="even">
-				<td><em>Cursor keys</em></td><td>Move around</td>
+			<tr>
+				<td><em>Cursor keys</em></td>
+				<td>Move around</td>
 			</tr>
-			<tr class="odd">
-				<td><em>PageUp</em></td><td>Jump 16 rows up</td>
+			<tr>
+				<td><em>PageUp</em></td>
+				<td>Jump 16 rows up</td>
 			</tr>
-			<tr class="even">
-				<td><em>PageDown</em></td><td>Jump 16 rows down</td>
+			<tr>
+				<td><em>PageDown</em></td>
+				<td>Jump 16 rows down</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Home</em></td><td>Jump to first row</td>
+			<tr>
+				<td><em>Home</em></td>
+				<td>Jump to first row</td>
 			</tr>
-			<tr class="even">
-				<td><em>End</em></td><td>Jump to last row</td>
+			<tr>
+				<td><em>End</em></td>
+				<td>Jump to last row</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Tab</em></td><td>Jump to next track</td>
+			<tr>
+				<td><em>Tab</em></td>
+				<td>Jump to next track</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Tab</em></td><td>Jump to previous track</td>
+			<tr>
+				<td><em>Shift-Tab</em></td>
+				<td>Jump to previous track</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Alt-Q&hellip;I</em></td><td>Jump to track (0&hellip;7) MOD N-Channels</td>
+			<tr>
+				<td><em>Alt-Q&hellip;I</em></td>
+				<td>Jump to track (0&hellip;7) MOD N-Channels</td>
 			</tr>
-			<tr class="even">
-				<td><em>Alt-A&hellip;K</em></td><td>Jump to track (8&hellip;15) MOD N-Channels</td>
+			<tr>
+				<td><em>Alt-A&hellip;K</em></td>
+				<td>Jump to track (8&hellip;15) MOD N-Channels</td>
 			</tr>
-			<tr class="odd">
-				<td><em>F9</em></td><td>Jump to beginning of the pattern</td>
+			<tr>
+				<td><em>F9</em></td>
+				<td>Jump to beginning of the pattern</td>
 			</tr>
-			<tr class="even">
-				<td><em>F10</em></td><td>Jump to position &frac14; through the pattern</td>
+			<tr>
+				<td><em>F10</em></td>
+				<td>Jump to position &frac14; through the pattern</td>
 			</tr>
-			<tr class="odd">
-				<td><em>F11</em></td><td>Jump to position halfway through the pattern</td>
+			<tr>
+				<td><em>F11</em></td>
+				<td>Jump to position halfway through the pattern</td>
 			</tr>
-			<tr class="even">
-				<td><em>F12</em></td><td>Jump to position &frac34; through the pattern</td>
+			<tr>
+				<td><em>F12</em></td>
+				<td>Jump to position &frac34; through the pattern</td>
 			</tr>
-			<tr class="odd">
-				<td><em>The key right of LShift</em></td><td>Enter key-off</td>
+			<tr>
+				<td><em>The key right of LShift</em></td>
+				<td>Enter key-off</td>
 			</tr>
-			<tr class="even">
-				<td><em>Caps-Lock</em></td><td>Enter key-off (Windows only)</td>
+			<tr>
+				<td><em>Caps-Lock</em></td>
+				<td>Enter key-off (Windows only)</td>
 			</tr>
-			<tr class="odd">
-				<td><em>1</em></td><td>Enter key-off</td>
+			<tr>
+				<td><em>1</em></td>
+				<td>Enter key-off</td>
 			</tr>
-			<tr class="even">
-				<td><em>Del</em></td><td>Delete note or volume column at cursor</td>
+			<tr>
+				<td><em>Del</em></td>
+				<td>Delete note or volume column at cursor</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Shift-Del</em></td><td>Delete note, volume and effect at cursor</td>
+			<tr>
+				<td><em>Shift-Del</em></td>
+				<td>Delete note, volume and effect at cursor</td>
 			</tr>
-			<tr class="even">
-				<td><em>Ctrl-Del</em></td><td>Delete volume and effect at cursor</td>
+			<tr>
+				<td><em>Ctrl-Del</em></td>
+				<td>Delete volume and effect at cursor</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Alt-Delete</em></td><td>Delete effect at cursor</td>
+			<tr>
+				<td><em>Alt-Delete</em></td>
+				<td>Delete effect at cursor</td>
 			</tr>
-			<tr class="even">
-				<td><em>Ins</em></td><td>Insert space on current track at cursor position (F13 on mac)</td>
+			<tr>
+				<td><em>Ins</em></td>
+				<td>Insert space on current track at cursor position (F13 on mac)</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Shift-Ins</em></td><td>Insert row at cursor position (shift-F13 on mac)</td>
+			<tr>
+				<td><em>Shift-Ins</em></td>
+				<td>Insert row at cursor position (shift-F13 on mac)</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Alt-Backspace</em></td><td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
+			<tr>
+				<td><em>Alt-Backspace</em></td>
+				<td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr class="even">
-				<td><em>Shift-Alt-Backspace</em></td><td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
+			<tr>
+				<td><em>Shift-Alt-Backspace</em></td>
+				<td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr class="even">
-				<td><em>Backspace</em></td><td>Delete previous note</td>
+			<tr>
+				<td><em>Backspace</em></td>
+				<td>Delete previous note</td>
 			</tr>
-			<tr class="odd">
-				<td><em>Shift-Backspace</em></td><td>Delete previous row</td>
+			<tr>
+				<td><em>Shift-Backspace</em></td>
+				<td>Delete previous row</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-Shift-V</em></td>
+				<td>Convert current pattern to sample</td>
 			</tr>
 		</table>
 		<h4>Clipboard operations:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-Cursor keys</em></td><td>Select block</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Alt-Cursor keys</em></td><td>Extend block</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F3</em></td><td>Cut block</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F4</em></td><td>Copy block (yes, even under Windows =)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F5</em></td><td>Paste block</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F6</em></td><td>Porous paste block</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F3</em></td><td>Cut track</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F4</em></td><td>Copy track</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F5</em></td><td>Paste track</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F6</em></td><td>Porous paste track</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F3</em></td><td>Cut pattern</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F4</em></td><td>Copy pattern</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F5</em></td><td>Paste pattern</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F6</em></td><td>Porous paste pattern</td>
 			</tr>
 		</table>
 		<h4>Additional shortcuts (not found in FT2):</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Alt-Z</em></td><td>Undo</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Alt-Y</em></td><td>Redo</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Alt-A</em></td><td>Select entire pattern</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-I</em></td><td>Interpolate values</td>
 			</tr>
 		</table>
 		<h4>Volume scaling:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-V</em></td><td>Volume scale block</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-V</em></td><td>Volume scale track</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-V</em></td><td>Volume scale pattern</td>
 			</tr>
 		</table>
 		<h4>Command/Volume macro:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Alt-1&hellip;0</em></td><td>Read command/volume at cursor</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-1&hellip;0</em></td><td>Write command/volume at cursor</td>
 			</tr>
 		</table>
 		<h4>Transpose:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F7</em></td><td>Transpose current instrument in block down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F8</em></td><td>Transpose current instrument in block up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F7</em></td><td>Transpose current instrument in track down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F8</em></td><td>Transpose current instrument in track up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F7</em></td><td>Transpose current instrument in pattern down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F8</em></td><td>Transpose current instrument in pattern up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt-F1</em></td><td>Transpose all instruments in block down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Alt-F2</em></td><td>Transpose all instruments in block up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-F1</em></td><td>Transpose all instruments in track down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-F2</em></td><td>Transpose all instruments in track up</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-F1</em></td><td>Transpose all instruments in pattern down</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-F2</em></td><td>Transpose all instruments in pattern up</td>
 			</tr>
 		</table>
 		<h4>Instrument selection:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Shift-Up</em></td><td>Select previous instrument</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Shift-Down</em></td><td>Select next instrument</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Ctrl-Shift-Up</em></td><td>Select previous sample</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl-Shift-Down</em></td><td>Select next sample</td>
 			</tr>
 		</table>
@@ -1156,40 +1221,40 @@
 			keypad, the layout is like this:
 		</p>
 		<table>
-			<tr class="even">
+			<tr >
 				<td>PC</td><td colspan="2">Mac</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Num 0&hellip;9</em></td><td><em>Num 0&hellip;9</em></td><td>Digit 0&hellip;9</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Num /</em></td><td><em>Num =</em></td><td>Digit A</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Num *</em></td><td><em>Num /</em></td><td>Digit B</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Num -</em></td><td><em>Num *</em></td><td>Digit C</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Num +</em></td><td><em>Num -</em></td><td>Digit D</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Num Enter</em></td><td><em>Num +</em></td><td>Digit E</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Num ,</em></td><td><em>Num Enter</em></td><td>Digit F</td>
 			</tr>
 		</table>
 		<h4>Sample editor:</h4>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Shift &amp; drag</em></td><td>Quick draw</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Ctrl &amp; drag</em></td><td>Resize selection</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Alt &amp; drag</em></td><td>Move selection or loop range</td>
 			</tr>
 		</table>
@@ -1199,25 +1264,25 @@
 		<h2><a id="effects">6. Effect command reference</a></h2>
 		<h3><a id="glossary">I. Glossary</a></h3>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>BPM</em></td><td>Traditionally Beats Per Minute, but in tracker terminology it defines the speed of ticks.</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Effect memory</em></td><td>When an effect command is called with 0 parameters, previous parameters are used.</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Row/line</em></td><td>Refers to one line of "text" on a pattern. In playback its duration depends on how many ticks there are per row (Speed) and fast they are (BPM).</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Sample fine-tune/volume/panning</em></td><td>Per sample default settings available through the instrument editor (thus also called instrument volume etc). Overrideable with effect commands. .MODs support these as well but with lower precision. (Save module and load back to enforce .MOD precision.)</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Tick</em></td><td>The base time unit in traditional trackers like MilkyTracker, originating from Amiga. Notes are triggered on the first tick of a row (unless delayed) and effects are applied on the following ticks.</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Semitone</em></td><td>The smallest musical interval in Western music and in MilkyTracker. A C# note is one semitone away from the note C.</td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Speed (Spd.)</em></td><td>Number of ticks per row.</td>
 			</tr>
 		</table>
@@ -1308,7 +1373,7 @@
 			<tr>
 				<td><em><code>y</code></em> = semitone offset</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1335,7 +1400,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 						<p>In MilkyTracker <span class="tooltip" title="The pattern dots ARE zeroes. Bricks shat, I know right.">you don't have to</span> and indeed you CAN'T enter the effect digit 0. Just start with the parameter digits and the effect digit will be filled in.</p>
@@ -1362,7 +1427,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = portamento speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1385,7 +1450,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>ProTracker 2/3</h4>
@@ -1404,7 +1469,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = portamento speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1421,7 +1486,7 @@
 					Works similarly to <a href="#fx1xx"><em><code>1xx</code></em> portamento up</a>, only bending note pitch down instead of up.
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>ProTracker 2/3</h4>
@@ -1440,7 +1505,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = portamento speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1472,7 +1537,7 @@
 			<tr>
 				<td><em><code>y</code></em> = depth</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1504,7 +1569,7 @@
 			<tr>
 				<td><em><code>y</code></em> = volume slide down speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1523,7 +1588,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>ProTracker 2/3</h4>
@@ -1545,7 +1610,7 @@
 			<tr>
 				<td><em><code>y</code></em> = volume slide down speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1564,7 +1629,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>ProTracker 2/3</h4>
@@ -1586,7 +1651,7 @@
 			<tr>
 				<td><em><code>y</code></em> = depth</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1615,7 +1680,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = panning position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1634,7 +1699,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>ProTracker 2/3</h4>
@@ -1657,7 +1722,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = sample offset</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1676,7 +1741,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Tips:</em></td>
 				<td>
 					Resampling a loop to exactly (0x10000=) 65536 bytes gives you the highest possible level of control over the sample.
@@ -1695,7 +1760,7 @@
 			<tr>
 				<td><em><code>y</code></em> = volume slide down speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1714,7 +1779,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<ul>
@@ -1736,7 +1801,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = song position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1755,7 +1820,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Tips:</em></td>
 				<td>
 					<p>
@@ -1773,7 +1838,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = volume</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1792,7 +1857,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<h4>Fasttracker II</h4>
@@ -1811,7 +1876,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = row number on next pattern</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1830,7 +1895,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -1851,7 +1916,7 @@
 			<tr>
 				<td><em><code>x</code></em> = portamento speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1880,7 +1945,7 @@
 			<tr>
 				<td><em><code>x</code></em> = portamento speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1909,7 +1974,7 @@
 			<tr>
 				<td><em><code>x</code></em> = glissando control toggle on/off</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1928,7 +1993,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -1946,7 +2011,7 @@
 			<tr>
 				<td><em><code>x</code></em> = vibrato waveform selection</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -1973,7 +2038,7 @@
 					</ul>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -1991,7 +2056,7 @@
 			<tr>
 				<td><em><code>x</code></em> = fine-tune</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2073,7 +2138,7 @@
 			<tr>
 				<td><em><code>x</code></em> = set loop point / number of iterations</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2092,7 +2157,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -2117,7 +2182,7 @@
 			<tr>
 				<td><em><code>x</code></em> = tremolo waveform selection</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2144,7 +2209,7 @@
 					</ul>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -2162,7 +2227,7 @@
 			<tr>
 				<td><em><code>x</code></em> = panning position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Explanation:</em></td>
 				<td>
 					<p>
@@ -2188,7 +2253,7 @@
 			<tr>
 				<td><em><code>x</code></em> = triggering interval</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2217,7 +2282,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2246,7 +2311,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2275,7 +2340,7 @@
 			<tr>
 				<td><em><code>x</code></em> = tick number</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2304,7 +2369,7 @@
 			<tr>
 				<td><em><code>x</code></em> = tick number</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2333,7 +2398,7 @@
 			<tr>
 				<td><em><code>x</code></em> = amount of rows</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2362,7 +2427,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = speed/BPM value</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2391,7 +2456,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = volume</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2423,7 +2488,7 @@
 			<tr>
 				<td><em><code>y</code></em> = volume slide down speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2442,7 +2507,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -2460,7 +2525,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = tick number</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2489,7 +2554,7 @@
 			<tr>
 				<td><em><code>xx</code></em> = envelope position</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2522,7 +2587,7 @@
 			<tr>
 				<td><em><code>y</code></em> = panning slide left speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2541,7 +2606,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -2562,7 +2627,7 @@
 			<tr>
 				<td><em><code>y</code></em> = triggering interval</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2599,7 +2664,7 @@
 					</ul>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>This command is very buggy from the start, straight from the source, Fasttracker II. While FT2's own documentation is inaccurate in many places, this is different. Extensive testing has revealed almost bizarre qualities of this effect and it's up to MilkyTracker to emulate it all. Without doubt the quirk the team has spent the most time and iterations working on getting it right. And still we advise to be careful with it. When using <em><code>Rxy</code></em>, check your song with FT2 (render to .WAV if you don't have the hardware (to emulate)), or at least BASS/XMPlay. And if you do find something odd, please report the bug as accurately and detailed as possible.
@@ -2630,7 +2695,7 @@
 			<tr>
 				<td><em><code>y</code></em> + 1 = ticks off</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2649,7 +2714,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -2667,7 +2732,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2696,7 +2761,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2723,7 +2788,7 @@
 			<tr>
 				<td><em>Syntax:</em></td><td><em><code>xx</code></em> = volume</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2752,7 +2817,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2781,7 +2846,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2810,7 +2875,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2839,7 +2904,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2868,7 +2933,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2887,7 +2952,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Tips:</em></td>
 				<td>
 					<p>
@@ -2905,7 +2970,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2924,7 +2989,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Tips:</em></td>
 				<td>
 					<p>
@@ -2942,7 +3007,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -2971,7 +3036,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -3000,7 +3065,7 @@
 			<tr>
 				<td><em><code>x</code></em> = speed</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -3029,7 +3094,7 @@
 			<tr>
 				<td><em><code>x</code></em> = depth</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Example:</em></td>
 				<td>
 					<code class="example">
@@ -3048,7 +3113,7 @@
 					</p>
 				</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>Notes:</em></td>
 				<td>
 					<p>
@@ -3065,15 +3130,15 @@
 			MilkyTracker supports basic MIDI input, which means you can use your MIDI device to feed notes into MilkyTracker. Enabling MIDI input varies a little from platform to platform - here's how to do it on&hellip;
 		</p>
 		<table>
-			<tr class="even">
+			<tr >
 				<td><em>Windows:</em></td>
 				<td>Select Preferences from the system menu (top left corner of the window)</td>
 			</tr>
-			<tr class="odd">
+			<tr >
 				<td><em>OSX:</em></td>
 				<td>Select Preferences from the MilkyTracker menu or press <em>Command-,</em></td>
 			</tr>
-			<tr class="even">
+			<tr >
 				<td><em>Linux:</em></td>
 				<td>Enabled by default if available on the system. See the Linux readme for details.</td>
 			</tr>

--- a/src/tracker/ModuleEditor.h
+++ b/src/tracker/ModuleEditor.h
@@ -34,6 +34,7 @@ class SampleEditor;
 class EnvelopeEditor;
 class ModuleServices;
 class PlayerCriticalSection;
+class Tracker;
 
 class ModuleEditor
 {
@@ -385,6 +386,7 @@ public:
 	static PPSystemString getTempFilename();
 	
 	friend class ChangesListener;
+	friend class Tracker;
 };
 
 #endif

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -28,6 +28,8 @@
 #include "ContextMenu.h"
 #include "Piano.h"
 #include "Tools.h"
+#include "Tracker.h"
+#include "SampleEditor.h"
 #include "TrackerConfig.h"
 #include "PlayerController.h"
 #include "DialogBase.h"
@@ -64,6 +66,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 										 EventListenerInterface* eventListener, 
 										 const PPPoint& location, 
 										 const PPSize& size, 
+										 Tracker& tracker,
 										 bool border/*= true*/) :
 	PPControl(id, parentScreen, eventListener, location, size),
 	border(border),
@@ -144,6 +147,8 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	subMenuXPaste->addEntry("Phase Modulate", MenuCommandIDPHPaste);
 	subMenuXPaste->addEntry("Flanger", MenuCommandIDFLPaste);
 	subMenuXPaste->addEntry("Selective EQ" PPSTR_PERIODS, MenuCommandIDSelectiveEQ10Band);
+	subMenuXPaste->addEntry("Capture pattern" PPSTR_PERIODS, MenuCommandIDCapturePattern);
+
 
 	subMenuPT = new PPContextMenu(6, parentScreen, this, PPPoint(0,0), TrackerConfig::colorThemeMain);
 	subMenuPT->addEntry("Boost", MenuCommandIDPTBoost);
@@ -178,6 +183,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	// Create tool handler responder
 	toolHandlerResponder = new ToolHandlerResponder(*this);
 	dialog = NULL;	
+	this->tracker = (Tracker *)&tracker;
 	
 	resetLastValues();
 }
@@ -1718,6 +1724,7 @@ void SampleEditorControl::hideContextMenu()
 
 void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 {
+
 	switch (commandId)
 	{
 		// cut
@@ -1788,6 +1795,10 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 		// Invoke tools
 		case MenuCommandIDNew:
 			invokeToolParameterDialog(ToolHandlerResponder::SampleToolTypeNew);
+			break;
+
+		case MenuCommandIDCapturePattern:
+			tracker->eventKeyDownBinding_InvokePatternCapture();
 			break;
 
 		case MenuCommandIDVolumeBoost:

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -26,7 +26,9 @@
 #include "BasicTypes.h"
 #include "Control.h"
 #include "Event.h"
+#include "Tracker.h"
 #include "SampleEditor.h"
+#include "EditorBase.h"
 #include "SampleEditorControlLastValues.h"
 
 // Forwards
@@ -63,6 +65,7 @@ private:
 	PPControl* caughtControl;
 	bool controlCaughtByLMouseButton, controlCaughtByRMouseButton;
 
+	Tracker* tracker;
 	PPContextMenu* editMenuControl;
 	PPContextMenu* subMenuAdvanced;
 	PPContextMenu* subMenuXPaste;
@@ -126,6 +129,7 @@ public:
 				 EventListenerInterface* eventListener, 
 				 const PPPoint& location, 
 				 const PPSize& size, 
+				 Tracker& tracker,
 				 bool border = true);
 
 	virtual ~SampleEditorControl();
@@ -296,6 +300,7 @@ private:
 		MenuCommandIDEQ3Band,
 		MenuCommandIDEQ10Band,
 		MenuCommandIDSelectiveEQ10Band,
+		MenuCommandIDCapturePattern,
 		MenuCommandIDGenerateSilence,
 		MenuCommandIDGenerateNoise,
 		MenuCommandIDGenerateSine,
@@ -363,7 +368,8 @@ private:
 	};
 
 	friend class ToolHandlerResponder;
-
+	friend class Tracker;
+	
 	PPDialogBase* dialog;
 	ToolHandlerResponder* toolHandlerResponder;
 	

--- a/src/tracker/SectionSamples.cpp
+++ b/src/tracker/SectionSamples.cpp
@@ -500,7 +500,7 @@ void SectionSamples::init(pp_int32 x, pp_int32 y)
 	PPContainer* sampleEditorContainer = new PPContainer(CONTAINER_SAMPLEEDITOR, screen, this, PPPoint(x, y), PPSize(screen->getWidth(), cHeight), false);
 	sampleEditorContainer->setColor(TrackerConfig::colorThemeMain);
 
-	sampleEditorControl = new SampleEditorControl(SAMPLE_EDITOR, screen, this, PPPoint(x+2, y+2), PPSize(sampleEditorContainer->getSize().width-4, sampleEditorContainer->getSize().height-4));
+	sampleEditorControl = new SampleEditorControl(SAMPLE_EDITOR, screen, this, PPPoint(x+2, y+2), PPSize(sampleEditorContainer->getSize().width-4, sampleEditorContainer->getSize().height-4), tracker );
 	sampleEditorControl->attachSampleEditor(tracker.moduleEditor->getSampleEditor());
 	sampleEditorControl->setBorderColor(TrackerConfig::colorThemeMain);
 

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -580,6 +580,8 @@ private:
     void eventKeyDownBinding_DecCurOrderPattern();
     void eventKeyDownBinding_IncCurOrderPattern();
 
+	void eventKeyDownBinding_InvokePatternCapture();
+
 
 private:
 	// - friend classes --------------------------------------------------------
@@ -609,6 +611,7 @@ private:
 	friend class RecorderLogic;
 	friend class Zapper;
 	friend class SectionSwitcher;
+	friend class SampleEditorControl;
 };
 
 #endif

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -1019,5 +1019,6 @@ void Tracker::eventKeyDownBinding_InvokePatternCapture()
 	sectionHDRecorder->insIndex = moduleEditor->currentInstrumentIndex;
 	sectionHDRecorder->fromOrder = getOrderListBoxIndex();
 	sectionHDRecorder->toOrder = getOrderListBoxIndex();
+  sectionHDRecorder->setSettingsAllowMuting(true);
 	sectionHDRecorder->exportWAVAsSample();
 }

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -171,6 +171,9 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DECIMAL, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DIVIDE, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 
+	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
+
+
 	// Key-down bindings for Fasttracker
 	// tab stuff
 	eventKeyDownBindingsFastTracker->addBinding('T', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_OpenTab);
@@ -260,6 +263,8 @@ void Tracker::initKeyBindings()
     eventKeyDownBindingsFastTracker->addBinding(VK_F10, KeyModifierCTRL, &Tracker::eventKeyDownBinding_InsNewOrderPosition);
     eventKeyDownBindingsFastTracker->addBinding(VK_F11, KeyModifierCTRL, &Tracker::eventKeyDownBinding_DecCurOrderPattern);
     eventKeyDownBindingsFastTracker->addBinding(VK_F12, KeyModifierCTRL, &Tracker::eventKeyDownBinding_IncCurOrderPattern);
+
+	eventKeyDownBindingsFastTracker->addBinding('V', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	eventKeyDownBindings = eventKeyDownBindingsMilkyTracker;
 }
@@ -1005,4 +1010,14 @@ void Tracker::eventKeyDownBinding_IncCurOrderPattern()
 {
 	moduleEditor->increaseOrderPosition(getOrderListBoxIndex());
 	updateOrderlist();
+}
+
+void Tracker::eventKeyDownBinding_InvokePatternCapture()
+{
+	sectionHDRecorder->selectSampleOutput();
+	sectionHDRecorder->smpIndex = moduleEditor->currentSampleIndex;
+	sectionHDRecorder->insIndex = moduleEditor->currentInstrumentIndex;
+	sectionHDRecorder->fromOrder = getOrderListBoxIndex();
+	sectionHDRecorder->toOrder = getOrderListBoxIndex();
+	sectionHDRecorder->exportWAVAsSample();
 }


### PR DESCRIPTION
What does it do?

* open the sample editor
* hit **CTRL-SHIFT-V** to 'sample' the current pattern into the waveform editor
* OR just rightclick "ext.paste" -> "capture pattern"

This commit serves various usecases:

* sounddesign: create new samples by combining samples in a pattern (kick/snare-layering e.g.)
* visualize & analyze the dynamics of your mixdown (spot phase issues e.g.)
* reduce mouse-menu-diving using disk.op->set wav->set order->currentsample and so on
* this is a lowhanging fruit since there were many requests for visualizing the mix (spectrum e.g.)

![image](https://user-images.githubusercontent.com/180068/124614270-5ba45100-de74-11eb-9049-9976d350deb6.png)
