### PR TITLE
added quick and dirty dynamic compression

### DIFF
--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -329,6 +329,7 @@ public:
 	// filters 
 	void tool_scaleSample(const FilterParameters* par);
 	void tool_normalizeSample(const FilterParameters* par);
+	void tool_compressSample(const FilterParameters* par);
 	void tool_reverseSample(const FilterParameters* par);
 	void tool_PTboostSample(const FilterParameters* par);
 	bool isValidxFadeSelection();

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -119,6 +119,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	subMenuAdvanced->addEntry("Volume boost" PPSTR_PERIODS, MenuCommandIDVolumeBoost);
 	subMenuAdvanced->addEntry("Volume fade" PPSTR_PERIODS, MenuCommandIDVolumeFade);
 	subMenuAdvanced->addEntry("Normalize", MenuCommandIDNormalize);
+	subMenuAdvanced->addEntry("Compress", MenuCommandIDCompress);
 	subMenuAdvanced->addEntry(seperatorStringLarge, -1);
 	subMenuAdvanced->addEntry("Backwards", MenuCommandIDReverse);
 	subMenuAdvanced->addEntry("Cross-fade", MenuCommandIDXFade);
@@ -1677,6 +1678,7 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	
 	// update submenu states
 	subMenuAdvanced->setState(MenuCommandIDNormalize, isEmptySample);
+	subMenuAdvanced->setState(MenuCommandIDCompress, isEmptySample);
 	subMenuAdvanced->setState(MenuCommandIDVolumeFade, isEmptySample);
 	subMenuAdvanced->setState(MenuCommandIDVolumeBoost, isEmptySample);
 	subMenuAdvanced->setState(MenuCommandIDReverse, isEmptySample);
@@ -1808,6 +1810,10 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 
 		case MenuCommandIDNormalize:
 			sampleEditor->tool_normalizeSample(NULL);
+			break;
+
+		case MenuCommandIDCompress:
+			sampleEditor->tool_compressSample(NULL);
 			break;
 
 		case MenuCommandIDReverse:

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -281,6 +281,7 @@ private:
 		MenuCommandIDPHPaste,
 		MenuCommandIDFLPaste,
 		MenuCommandIDNormalize,
+		MenuCommandIDCompress,
 		MenuCommandIDVolumeBoost,
 		MenuCommandIDVolumeFade,
 		MenuCommandIDReverse,


### PR DESCRIPTION
This allows for various usecases:

* deadsimple param-less way to tame dynamics, louder vocals, expand the dynamic range
* apply tube-like/soft-clipping distortion
* use 'redo filter' to intensify the effect (further)

![milkycompress](https://user-images.githubusercontent.com/180068/124637628-489c7b80-de8a-11eb-8db0-458f7e9a0d79.gif)
