### PR TITLE
Feature: Add 9xx adjustment option to sample resampler

### DIFF
--- a/src/tracker/DialogResample.cpp
+++ b/src/tracker/DialogResample.cpp
@@ -95,7 +95,7 @@ DialogResample::DialogResample(PPScreen* screen,
 	resamplerHelper(new ResamplerHelper()),
 	interpolationType(1),
 	adjustFtAndRelnote(true),
-	adjustSampleOffsetCommand(true)
+	adjustSampleOffsetCommand(false)
 {
 #ifdef __LOWRES__
 	initDialog(screen, responder, id, "Resample" PPSTR_PERIODS, 290, 158+15+20+16, 26+15, "Ok", "Cancel");
@@ -201,22 +201,22 @@ DialogResample::DialogResample(PPScreen* screen,
 	y2+=16;
 
 	x2 = x + width / 2 - (10 * 8 + 35 + 14 * 8) / 2 + 21 * 8;
-	checkBox = new PPCheckBox(MESSAGEBOX_CONTROL_USER2, screen, this, PPPoint(x2, y2 + 1));
-	checkBox->checkIt(adjustFtAndRelnote);
-	messageBoxContainerGeneric->addControl(checkBox);
+	checkBoxAdjustFtAndRelnote = new PPCheckBox(MESSAGEBOX_CONTROL_USER2, screen, this, PPPoint(x2, y2 + 1));
+	checkBoxAdjustFtAndRelnote->checkIt(adjustFtAndRelnote);
+	messageBoxContainerGeneric->addControl(checkBoxAdjustFtAndRelnote);
 
 	x2 -= 21 * 8;
-	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust Ft/Rel.Note:", checkBox, true));	
+	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust Ft/Rel.Note:", checkBoxAdjustFtAndRelnote, true));	
 
 	y2+=16;
 
 	x2 = x + width / 2 - (10 * 8 + 35 + 14 * 8) / 2 + 21 * 8;
-	checkBox = new PPCheckBox(MESSAGEBOX_CONTROL_USER3, screen, this, PPPoint(x2, y2 + 1));
-	checkBox->checkIt(adjustSampleOffsetCommand);
-	messageBoxContainerGeneric->addControl(checkBox);
+	checkBoxAdjustSampleOffsetCommand = new PPCheckBox(MESSAGEBOX_CONTROL_USER3, screen, this, PPPoint(x2, y2 + 1));
+	checkBoxAdjustSampleOffsetCommand->checkIt(adjustSampleOffsetCommand);
+	messageBoxContainerGeneric->addControl(checkBoxAdjustSampleOffsetCommand);
 
 	x2 -= 21 * 8;
-	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust 9xx commands:", checkBox, true));
+	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust 9xx commands:", checkBoxAdjustSampleOffsetCommand, true));
 
 	y2+=16;
 
@@ -441,7 +441,8 @@ void DialogResample::updateListBoxes()
 	PPStaticText* staticText = static_cast<PPStaticText*>(messageBoxContainerGeneric->getControlByID(MESSAGEBOX_STATICTEXT_USER1));
 	staticText->setHexValue(finalSize, 8);	
 
-	checkBox->checkIt(adjustFtAndRelnote);
+	checkBoxAdjustFtAndRelnote->checkIt(adjustFtAndRelnote);
+	checkBoxAdjustSampleOffsetCommand->checkIt(adjustSampleOffsetCommand);
 }
 
 void DialogResample::updateListBox(pp_int32 id, float val, pp_int32 numDecimals)

--- a/src/tracker/DialogResample.cpp
+++ b/src/tracker/DialogResample.cpp
@@ -94,12 +94,13 @@ DialogResample::DialogResample(PPScreen* screen,
 	count(0),
 	resamplerHelper(new ResamplerHelper()),
 	interpolationType(1),
-	adjustFtAndRelnote(true)
+	adjustFtAndRelnote(true),
+	adjustSampleOffsetCommand(true)
 {
 #ifdef __LOWRES__
-	initDialog(screen, responder, id, "Resample" PPSTR_PERIODS, 290, 142+15+20+16, 26+15, "Ok", "Cancel");
+	initDialog(screen, responder, id, "Resample" PPSTR_PERIODS, 290, 158+15+20+16, 26+15, "Ok", "Cancel");
 #else
-	initDialog(screen, responder, id, "Resample" PPSTR_PERIODS, 290, 142+20+16, 26, "Ok", "Cancel");
+	initDialog(screen, responder, id, "Resample" PPSTR_PERIODS, 290, 158+20+16, 26, "Ok", "Cancel");
 #endif
 
 	pp_int32 x = getMessageBoxContainer()->getLocation().x;
@@ -206,7 +207,17 @@ DialogResample::DialogResample(PPScreen* screen,
 
 	x2 -= 21 * 8;
 	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust Ft/Rel.Note:", checkBox, true));	
-	
+
+	y2+=16;
+
+	x2 = x + width / 2 - (10 * 8 + 35 + 14 * 8) / 2 + 21 * 8;
+	checkBox = new PPCheckBox(MESSAGEBOX_CONTROL_USER3, screen, this, PPPoint(x2, y2 + 1));
+	checkBox->checkIt(adjustSampleOffsetCommand);
+	messageBoxContainerGeneric->addControl(checkBox);
+
+	x2 -= 21 * 8;
+	messageBoxContainerGeneric->addControl(new PPCheckBoxLabel(0, screen, this, PPPoint(x2, y2 + 2), "Adjust 9xx commands:", checkBox, true));
+
 	y2+=16;
 
 #ifdef __LOWRES__
@@ -372,6 +383,14 @@ pp_int32 DialogResample::handleEvent(PPObject* sender, PPEvent* event)
 				break;
 			}
 
+			case MESSAGEBOX_CONTROL_USER3:
+			{
+				if (event->getID() != eCommand)
+					break;
+
+				this->adjustSampleOffsetCommand = reinterpret_cast<PPCheckBox*>(sender)->isChecked();
+				break;
+			}
 		}
 	}
 	else if (event->getID() == eValueChanged)

--- a/src/tracker/DialogResample.h
+++ b/src/tracker/DialogResample.h
@@ -37,7 +37,8 @@ class DialogResample : public PPDialogBase
 {
 private:
 	class PPListBox* listBoxes[3];
-	class PPCheckBox* checkBox;
+	class PPCheckBox* checkBoxAdjustFtAndRelnote;
+	class PPCheckBox* checkBoxAdjustSampleOffsetCommand;
 	pp_int32 currentSelectedListBox;
 	pp_int32 relnote, finetune;
 	pp_uint32 size, finalSize;

--- a/src/tracker/DialogResample.h
+++ b/src/tracker/DialogResample.h
@@ -48,6 +48,7 @@ private:
 	class ResamplerHelper* resamplerHelper;
 	pp_int32 interpolationType;
 	bool adjustFtAndRelnote;
+	bool adjustSampleOffsetCommand;
 
 public:
 	DialogResample(PPScreen* screen, 
@@ -74,7 +75,10 @@ public:
 
 	void setAdjustFtAndRelnote(bool adjustFtAndRelnote) { this->adjustFtAndRelnote = adjustFtAndRelnote; }
 	bool getAdjustFtAndRelnote() const { return adjustFtAndRelnote; }
-	
+
+	void setAdjustSampleOffsetCommand(bool adjustSampleOffsetCommand) { this->adjustSampleOffsetCommand = adjustSampleOffsetCommand; }
+	bool getAdjustSampleOffsetCommand() const { return adjustSampleOffsetCommand; }
+
 private:
 	void listBoxEnterEditState(pp_int32 id);
 	

--- a/src/tracker/ModuleEditor.cpp
+++ b/src/tracker/ModuleEditor.cpp
@@ -80,10 +80,10 @@ private:
 					moduleEditor.finishSamples();
 					if (moduleEditor.sampleEditor->isLastOperationResampling())
 					{
-						const bool adjustSampleOffsetCommands = moduleEditor.sampleEditor->getLastParameters()->getParameter(3).intPart;
-						if (adjustSampleOffsetCommands)
+						const bool adjustSampleOffsetCommand = moduleEditor.sampleEditor->getLastParameters()->getParameter(3).intPart;
+						if (adjustSampleOffsetCommand)
 						{
-							moduleEditor.adjustSampleOffsetCommandsAfterSampleSizeChange(moduleEditor.sampleEditor->getSample(), moduleEditor.sampleEditor->getUndoSample()->getSampLen());
+							moduleEditor.adjustSampleOffsetCommandAfterSampleSizeChange(moduleEditor.sampleEditor->getSample(), moduleEditor.sampleEditor->getUndoSample()->getSampLen());
 						}
 					}
 				}
@@ -2474,7 +2474,7 @@ void ModuleEditor::optimizeSamples(bool convertTo8Bit, bool minimize,
 		changed = true;
 }
 
-pp_int32 ModuleEditor::adjustSampleOffsetCommandsAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize)
+pp_int32 ModuleEditor::adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize)
 {
 	mp_sint32 i,j;
 
@@ -2508,7 +2508,7 @@ pp_int32 ModuleEditor::adjustSampleOffsetCommandsAfterSampleSizeChange(TXMSample
 					for (mp_sint32 k = 0; k < pattern->effnum; k++) {
 						if (src[k * 2 + 2] == 0x9) {
 
-							mp_sint32 op = (((mp_sint32)src[k * 2 + 3]) << 8);
+							mp_sint32 op = src[k * 2 + 3];
 							if (lastIns[j])
 							{
 								mp_sint32 insIndex = lastIns[j] - 1;
@@ -2520,7 +2520,10 @@ pp_int32 ModuleEditor::adjustSampleOffsetCommandsAfterSampleSizeChange(TXMSample
 									if (&module->smp[smpIndex] == sample)
 									{
 										const float factor = (float)sample->samplen / (float)oldSize;
-										op = ((mp_sint32)((float)op * factor)) >> 8;
+										op = (mp_sint32)roundf(op * factor);
+										if (op > 255) {
+											op = 255;
+										}
 										src[k * 2 + 3] = (mp_ubyte)op;
 									}
 								}

--- a/src/tracker/ModuleEditor.cpp
+++ b/src/tracker/ModuleEditor.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <new>
+#include <math.h>
 #include "ModuleEditor.h"
 #include "PatternEditor.h"
 #include "SampleEditor.h"

--- a/src/tracker/ModuleEditor.cpp
+++ b/src/tracker/ModuleEditor.cpp
@@ -2475,7 +2475,7 @@ void ModuleEditor::optimizeSamples(bool convertTo8Bit, bool minimize,
 		changed = true;
 }
 
-pp_int32 ModuleEditor::adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize)
+void ModuleEditor::adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize)
 {
 	mp_sint32 i,j;
 

--- a/src/tracker/ModuleEditor.h
+++ b/src/tracker/ModuleEditor.h
@@ -380,7 +380,7 @@ public:
 						 mp_sint32& numConvertedSamples, mp_sint32& numMinimizedSamples,
 						 bool evaluate);
 
-	pp_int32 adjustSampleOffsetCommandsAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize);
+	pp_int32 adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize);
 						 
 public:
 	static void insertText(char* dst, const char* src, mp_sint32 max);

--- a/src/tracker/ModuleEditor.h
+++ b/src/tracker/ModuleEditor.h
@@ -380,7 +380,7 @@ public:
 						 mp_sint32& numConvertedSamples, mp_sint32& numMinimizedSamples,
 						 bool evaluate);
 
-	pp_int32 adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize);
+	void adjustSampleOffsetCommandAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize);
 						 
 public:
 	static void insertText(char* dst, const char* src, mp_sint32 max);

--- a/src/tracker/ModuleEditor.h
+++ b/src/tracker/ModuleEditor.h
@@ -378,6 +378,8 @@ public:
 	void optimizeSamples(bool convertTo8Bit, bool minimize, 
 						 mp_sint32& numConvertedSamples, mp_sint32& numMinimizedSamples,
 						 bool evaluate);
+
+	pp_int32 adjustSampleOffsetCommandsAfterSampleSizeChange(TXMSample *sample, pp_int32 oldSize);
 						 
 public:
 	static void insertText(char* dst, const char* src, mp_sint32 max);

--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -804,6 +804,18 @@ pp_int32 SampleEditor::getPanning() const
 	return sample ? sample->pan : 0;
 }
 
+bool SampleEditor::isLastOperationResampling() const {
+	return lastFilterFunc == &SampleEditor::tool_resampleSample;
+}
+
+const FilterParameters* SampleEditor::getLastParameters() const {
+	return lastParameters;
+}
+
+const SampleUndoStackEntry* SampleEditor::getUndoSample() const {
+	return before;
+}
+
 void SampleEditor::startDrawing()
 {
 	if (sample)

--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -239,6 +239,10 @@ public:
 
 	bool isEmpty() const { if (sample && !sample->sample) return true; else return false; } 
 
+	bool isLastOperationResampling() const;
+	const FilterParameters* getLastParameters() const;
+	const SampleUndoStackEntry* getUndoSample() const;
+
 	void startDrawing();
 	bool isDrawing() const { return drawing; }
 	void drawSample(pp_int32 sampleIndex, float s);

--- a/src/tracker/SampleEditorControlLastValues.h
+++ b/src/tracker/SampleEditorControlLastValues.h
@@ -47,7 +47,7 @@ struct SampleEditorControlLastValues
 	
 	pp_int32 resampleInterpolationType;
 	bool adjustFtAndRelnote;
-	bool adjustSampleOffsetCommands;
+	bool adjustSampleOffsetCommand;
 	
 	static float invalidFloatValue() 
 	{
@@ -73,7 +73,7 @@ struct SampleEditorControlLastValues
 		hasEQ3BandValues = hasEQ10BandValues = false;
 		resampleInterpolationType = invalidIntValue();
 		adjustFtAndRelnote = true;
-		adjustSampleOffsetCommands = true;
+		adjustSampleOffsetCommand = false;
 	}
 		
 	PPDictionary convertToDictionary()
@@ -100,7 +100,7 @@ struct SampleEditorControlLastValues
 		
 		result.store("adjustFtAndRelnote", adjustFtAndRelnote);
 
-		result.store("adjustSampleOffsetCommands", adjustSampleOffsetCommands);
+		result.store("adjustSampleOffsetCommands", adjustSampleOffsetCommand);
 		return result;
 	}
 	
@@ -155,7 +155,7 @@ struct SampleEditorControlLastValues
 			}
 			else if (key->getKey().compareToNoCase("adjustSampleOffsetCommands") == 0)
 			{
-				adjustSampleOffsetCommands = key->getBoolValue();
+				adjustSampleOffsetCommand = key->getBoolValue();
 			}
 
 			key = dictionary.getNextKey();

--- a/src/tracker/SampleEditorControlLastValues.h
+++ b/src/tracker/SampleEditorControlLastValues.h
@@ -47,6 +47,7 @@ struct SampleEditorControlLastValues
 	
 	pp_int32 resampleInterpolationType;
 	bool adjustFtAndRelnote;
+	bool adjustSampleOffsetCommands;
 	
 	static float invalidFloatValue() 
 	{
@@ -72,6 +73,7 @@ struct SampleEditorControlLastValues
 		hasEQ3BandValues = hasEQ10BandValues = false;
 		resampleInterpolationType = invalidIntValue();
 		adjustFtAndRelnote = true;
+		adjustSampleOffsetCommands = true;
 	}
 		
 	PPDictionary convertToDictionary()
@@ -97,6 +99,8 @@ struct SampleEditorControlLastValues
 		result.store("resampleInterpolationType", resampleInterpolationType);
 		
 		result.store("adjustFtAndRelnote", adjustFtAndRelnote);
+
+		result.store("adjustSampleOffsetCommands", adjustSampleOffsetCommands);
 		return result;
 	}
 	
@@ -149,7 +153,11 @@ struct SampleEditorControlLastValues
 			{
 				adjustFtAndRelnote = key->getBoolValue();
 			}
-		
+			else if (key->getKey().compareToNoCase("adjustSampleOffsetCommands") == 0)
+			{
+				adjustSampleOffsetCommands = key->getBoolValue();
+			}
+
 			key = dictionary.getNextKey();
 		}
 	}

--- a/src/tracker/SampleEditorControlToolHandler.cpp
+++ b/src/tracker/SampleEditorControlToolHandler.cpp
@@ -234,6 +234,7 @@ bool SampleEditorControl::invokeTool(ToolHandlerResponder::SampleToolTypes type)
 		{
 			lastValues.resampleInterpolationType = static_cast<DialogResample*>(dialog)->getInterpolationType();
 			lastValues.adjustFtAndRelnote = static_cast<DialogResample*>(dialog)->getAdjustFtAndRelnote();
+			lastValues.adjustSampleOffsetCommand = static_cast<DialogResample*>(dialog)->getAdjustSampleOffsetCommand();
 
 			FilterParameters par(4);
 			par.setParameter(0, FilterParameters::Parameter(static_cast<DialogResample*>(dialog)->getC4Speed()));

--- a/src/tracker/SampleEditorControlToolHandler.cpp
+++ b/src/tracker/SampleEditorControlToolHandler.cpp
@@ -233,10 +233,11 @@ bool SampleEditorControl::invokeTool(ToolHandlerResponder::SampleToolTypes type)
 			lastValues.resampleInterpolationType = static_cast<DialogResample*>(dialog)->getInterpolationType();
 			lastValues.adjustFtAndRelnote = static_cast<DialogResample*>(dialog)->getAdjustFtAndRelnote();
 
-			FilterParameters par(3);
+			FilterParameters par(4);
 			par.setParameter(0, FilterParameters::Parameter(static_cast<DialogResample*>(dialog)->getC4Speed()));
 			par.setParameter(1, FilterParameters::Parameter(static_cast<pp_int32>(lastValues.resampleInterpolationType)));
 			par.setParameter(2, FilterParameters::Parameter(lastValues.adjustFtAndRelnote ? 1 : 0));
+			par.setParameter(3, FilterParameters::Parameter(lastValues.adjustSampleOffsetCommands ? 1 : 0));
 			sampleEditor->tool_resampleSample(&par);
 			break;
 		}

--- a/src/tracker/SampleEditorControlToolHandler.cpp
+++ b/src/tracker/SampleEditorControlToolHandler.cpp
@@ -239,7 +239,7 @@ bool SampleEditorControl::invokeTool(ToolHandlerResponder::SampleToolTypes type)
 			par.setParameter(0, FilterParameters::Parameter(static_cast<DialogResample*>(dialog)->getC4Speed()));
 			par.setParameter(1, FilterParameters::Parameter(static_cast<pp_int32>(lastValues.resampleInterpolationType)));
 			par.setParameter(2, FilterParameters::Parameter(lastValues.adjustFtAndRelnote ? 1 : 0));
-			par.setParameter(3, FilterParameters::Parameter(lastValues.adjustSampleOffsetCommands ? 1 : 0));
+			par.setParameter(3, FilterParameters::Parameter(lastValues.adjustSampleOffsetCommand ? 1 : 0));
 			sampleEditor->tool_resampleSample(&par);
 			break;
 		}


### PR DESCRIPTION
Allows that all 9xx commands affected by a resampling operation are computationally adjusted automatically. While the sample operation can be undone, the 9xx change can unfortunately not be undone, because there is no undo stack on entire song operations.