### PR TITLE
Fix muting when exporting for over 32 channels (issue #242)

### DIFF
--- a/src/milkyplay/PlayerBase.cpp
+++ b/src/milkyplay/PlayerBase.cpp
@@ -182,6 +182,11 @@ void PlayerBase::restart(mp_uint32 startPosition/* = 0*/, mp_uint32 startRow/* =
 //////////////////////////////////////////////////////
 // setup mixer and start playing
 //////////////////////////////////////////////////////
+void PlayerBase::setNumChannelMixerChannelsToModuleCount(XModule *module)
+{
+	ChannelMixer::setNumChannels(module->header.channum);
+}
+
 mp_sint32 PlayerBase::startPlaying(XModule *module,
 							   bool repeat /* = false*/,
 							   mp_uint32 startPosition /* = 0*/, 

--- a/src/milkyplay/PlayerBase.h
+++ b/src/milkyplay/PlayerBase.h
@@ -229,6 +229,8 @@ public:
 
 	virtual void resetAllSpeed() {}	
 	
+	virtual void setNumChannelMixerChannelsToModuleCount(XModule *module);
+
 	virtual mp_sint32   startPlaying(XModule* module, 
 									 bool repeat = false, 
 									 mp_uint32 startPosition = 0, 

--- a/src/milkyplay/PlayerGeneric.cpp
+++ b/src/milkyplay/PlayerGeneric.cpp
@@ -973,6 +973,12 @@ mp_sint32 PlayerGeneric::exportToWAV(const SYSCHAR* fileName, XModule* module,
 
 	if (player)
 	{
+		// Resize channel mixer count before muting to make sure muting happens correctly.
+		// If it can be verified that calling the muting code after player->startPlaying but
+		// before mixer.start doesn't cause any issues, this function can be removed
+		// and the muting code moved after player->startPlaying.
+		player->setNumChannelMixerChannelsToModuleCount(module);
+		
 		if (mutingArray && mutingNumChannels > 0 && mutingNumChannels <= module->header.channum)
 		{
 			for (mp_uint32 i = 0; i < mutingNumChannels; i++)


### PR DESCRIPTION
Added the function `PlayerBase::setNumChannelMixerChannelsToModuleCount` to call `ChannelMixer::setNumChannels` from `PlayerGeneric::exportToWAV`.

This makes sure the channels get resized before the muting code so it mutes channels as expected while exporting when there are over 32 channels, as otherwise the resize happens after and discards the channel muting.

Added a comment with the full breakdown of my investigation into this here: https://github.com/milkytracker/MilkyTracker/issues/242#issuecomment-918642675