### PR TITLE
Fix scrolling in vertical scrollbars with up/down buttons by adding metaData value to pass  (Issue #253)

### DIFF
--- a/src/ppui/Scrollbar.cpp
+++ b/src/ppui/Scrollbar.cpp
@@ -518,7 +518,7 @@ pp_int32 PPScrollbar::handleEvent(PPObject* sender, PPEvent* event)
 		)
 	{
 		// Call parent event listener
-		PPEvent e(eBarScrollUp);
+		PPEvent e(eBarScrollUp, 1); //metaData=1 for scrolling with the scrollbar buttons
 		return eventListener->handleEvent(reinterpret_cast<PPObject*>(this), &e);
 	}
 	if (
@@ -533,7 +533,7 @@ pp_int32 PPScrollbar::handleEvent(PPObject* sender, PPEvent* event)
 		)
 	{
 		// Call parent event listener
-		PPEvent e(eBarScrollDown);
+		PPEvent e(eBarScrollDown, 1); //metaData=1 for scrolling with the scrollbar buttons
 		return eventListener->handleEvent(reinterpret_cast<PPObject*>(this), &e);
 	}
 	else if (/*event->getID() == eLMouseDown &&*/


### PR DESCRIPTION
Added a metaData of 1 to pass to with eBarScrollUp and eBarScrollDown events, so that when you click the up or down buttons in a scrollbar being used by another widget it scrolls 1 line at a time, instead of 0.

More details in #253.