### PR TITLE
Fix About screen out-of-bounds read/crash caused by missing null terminator

### DIFF
--- a/src/tracker/AnimatedFXControl.cpp
+++ b/src/tracker/AnimatedFXControl.cpp
@@ -141,6 +141,7 @@ AnimatedFXControl::AnimatedFXControl(pp_int32 id,
 	
 	textBufferMaxChars = visibleWidth*2 / font->getCharWidth();
 	textBuffer = new char[textBufferMaxChars + 1];
+	textBuffer[textBufferMaxChars] = '\0';
 
 	currentCharIndex = 0;
 	pp_int32 j = currentCharIndex % strlen(text);


### PR DESCRIPTION
When building with ASAN enabled (CMake flags `-DCMAKE_CXX_FLAGS=-fsanitize=address -DCMAKE_LINKER_FLAGS=-fsanitize=address`), I get a crash in `PPGraphics_32bpp_generic::drawString()` dereferencing invalid memory in `str`. The method is called by `AnimatedFXControl::paint` printing `textBuffer`, which is a string that isn't properly null-terminated, causing `drawString` to read past the end of valid memory if the final byte is nonzero.

This PR writes a null terminator to the buffer so the message is printed properly. It seems to never be overwritten (because `textBuffer` has a fixed length), and I tested that the message is printed properly when it reaches the end and loops (though I shortened the message to reduce the wait time).