### PR TITLE
Fix uninitialized memory being used

### DIFF
--- a/src/fx/TexturedGrid.cpp
+++ b/src/fx/TexturedGrid.cpp
@@ -24,6 +24,7 @@
 #include "Math3d.h"
 #include "Filter.h"
 #include "Texture.h"
+#include <stdint.h>
 
 #define PRGB2SHORT(r,g,b) ((((r))<<11)+(((g))<<5)+((b))) 
 #define RGB2SHORT(r,g,b) ((((r>>3))<<11)+(((g>>2))<<5)+((b>>3))) 
@@ -46,10 +47,9 @@ TexturedGrid::TexturedGrid(int width, int height, int gridshift)
 	this->gridHeight = (height>>gridshift)+1;
 
 	grid = new VectorFP[gridWidth*gridHeight];
+	memset(this->grid, 0, (size_t) gridWidth * gridHeight * sizeof(VectorFP));
 
 	this->texture = NULL;	// we're not rendering anything until texture is set
-
-	this->buffer = new unsigned short[width*height];
 
 	// for debugging, load texture
 	int i;
@@ -109,9 +109,6 @@ TexturedGrid::~TexturedGrid()
 {
 	if (grid)
 		delete[] grid;
-
-	if (buffer)
-		delete[] buffer;
 
 	if (texture)
 		delete[] texture;

--- a/src/fx/TexturedGrid.h
+++ b/src/fx/TexturedGrid.h
@@ -38,7 +38,6 @@ protected:
 	int				gridWidth, gridHeight;
 
 	unsigned short* texture;
-	unsigned short* buffer;
 
 	int				sintab[1024];
 

--- a/src/ppui/BasicTypes.h
+++ b/src/ppui/BasicTypes.h
@@ -170,7 +170,8 @@ struct PPColor
 		r(red), g(green), b(blue)
 	{}
 
-	PPColor()
+	PPColor() :
+		r(), g(), b()
 	{}
 	
 	void validate()

--- a/src/ppui/ListBox.cpp
+++ b/src/ppui/ListBox.cpp
@@ -63,12 +63,21 @@ PPListBox::PPListBox(pp_int32 id, PPScreen* parentScreen, EventListenerInterface
 					 bool scrollable/* = true*/,
 					 bool showSelectionAlways/*= false*/) :
 	PPControl(id, parentScreen, eventListener, location, size),
+	border(border),
 	borderColor(&PPUIConfig::getInstance()->getColor(PPUIConfig::ColorListBoxBorder)),
 	backGroundButtonColor(&PPUIConfig::getInstance()->getColor(PPUIConfig::ColorListBoxBackground)),
 	// default textcolor 
 	textColor(&PPUIConfig::getInstance()->getColor(PPUIConfig::ColorStaticText)),
+
+	editable(editable),
+	scrollable(scrollable),
 	autoHideVScroll(true),
 	autoHideHScroll(true),
+
+	showIndex(false),
+	indexBaseCount(1),
+
+	showSelectionAlways(showSelectionAlways),
 	selectionVisible(true),
 	onlyShowIndexSelection(false),
 	keepsFocus(true),
@@ -78,22 +87,44 @@ PPListBox::PPListBox(pp_int32 id, PPScreen* parentScreen, EventListenerInterface
 	singleButtonClickEdit(false),
 	allowDragSelection(true),
 	rightButtonConfirm(false),
+
+	items(NULL),
+	startIndex(0),
+	startPos(0),
+	selectionIndex(showSelectionAlways ? 0 : -1),
+	columnSelectionStart(-1),
+	columnSelectionEnd(-1),
+	// "unlimited" editing
+	maxEditSize(-1),
+	timerTicker(0),
+	lastTimerState(false),
+
+	visibleHeight(0),
+	visibleWidth(0),
+
+	backgroundButton(NULL),
+
 	hScrollbar(NULL),
 	vScrollbar(NULL),
+
+	caughtControl(NULL),
+	controlCaughtByLMouseButton(false), controlCaughtByRMouseButton(false),
+	lMouseDown(false), rMouseDown(false),
+
+	font(NULL),
+
+	editCopy(NULL),
+
+	lastStartIndex(0),
+	lastStartPos(0),
+	lastSelectionIndex(0),
+	hadVScrollbar(false),
+	hadHScrollbar(false),
+
 	colorQueryListener(NULL)
 {
-	this->border = border;
-
-	this->editable = editable;
-	this->scrollable = scrollable;
-
-	this->showSelectionAlways = showSelectionAlways;
-
-	showIndex = false;
 	indexBaseCount = 1;
 
-	// "unlimited" editing
-	maxEditSize = -1;
 
 	//this->clickable = clickable;
 
@@ -103,19 +134,7 @@ PPListBox::PPListBox(pp_int32 id, PPScreen* parentScreen, EventListenerInterface
 	// create background button
 	initialize();
 
-	caughtControl = NULL;
-	controlCaughtByLMouseButton = controlCaughtByRMouseButton = false;
-	lMouseDown = rMouseDown = false;
-
 	font = PPFont::getFont(PPFont::FONT_SYSTEM);
-
-	startIndex = 0;	
-	startPos = 0;
-	timerTicker = 0;
-
-	selectionIndex = showSelectionAlways ? 0 : -1;
-	
-	columnSelectionStart = -1;
 
 	adjustScrollbars();
 

--- a/src/tracker/AnimatedFXControl.cpp
+++ b/src/tracker/AnimatedFXControl.cpp
@@ -141,6 +141,7 @@ AnimatedFXControl::AnimatedFXControl(pp_int32 id,
 	
 	textBufferMaxChars = visibleWidth*2 / font->getCharWidth();
 	textBuffer = new char[textBufferMaxChars + 1];
+	textBuffer[textBufferMaxChars] = '\0';
 
 	currentCharIndex = 0;
 	pp_int32 j = currentCharIndex % strlen(text);

--- a/src/tracker/AnimatedFXControl.cpp
+++ b/src/tracker/AnimatedFXControl.cpp
@@ -119,7 +119,7 @@ AnimatedFXControl::AnimatedFXControl(pp_int32 id,
 									 bool border/*= true*/) :
 	PPControl(id, parentScreen, eventListener, location, size),
 	borderColor(&ourOwnBorderColor),
-	fx(NULL), vscreen(NULL)
+	fx(NULL), vscreen(NULL), fxTicker(0)
 {
 	this->border = border;
 

--- a/src/tracker/AnimatedFXControl.h
+++ b/src/tracker/AnimatedFXControl.h
@@ -55,7 +55,7 @@ private:
 	pp_int32 fxTicker;
 	
 	class PPFont* font;
-	pp_int32 xPos, currentSpeed;
+	pp_int32 xPos;
 	pp_int32 currentCharIndex;
 	pp_uint32 textBufferMaxChars;
 	pp_uint32 lastTime;

--- a/src/tracker/PatternEditorControl.h
+++ b/src/tracker/PatternEditorControl.h
@@ -66,7 +66,9 @@ private:
 		pp_int32 startIndex;
 		pp_int32 startPos;
 		
-		UndoInfo()
+		UndoInfo() :
+			startIndex(),
+			startPos()
 		{
 		}
 		
@@ -82,8 +84,6 @@ private:
 	const PPColor* cursorColor;
 	const PPColor* selectionColor;
 
-	bool border;
-	
 	struct Properties
 	{
 		bool showFocus;
@@ -177,7 +177,6 @@ private:
 
 	// edit menu
 	pp_int32 menuPosX;
-	pp_int32 menuPosXOffset;
 	pp_int32 menuPosY;
 	pp_int32 menuInvokeChannel;
 	pp_int32 lastMenuInvokeChannel;

--- a/src/tracker/PatternTools.h
+++ b/src/tracker/PatternTools.h
@@ -34,7 +34,6 @@ private:
 	pp_int32 offset;
 	pp_int32 currentEffectIndex;
 	struct TXMPattern* pattern;
-	pp_int32 lockOffset;
 
 public:
 	PatternTools() :

--- a/src/tracker/PianoControl.cpp
+++ b/src/tracker/PianoControl.cpp
@@ -103,10 +103,19 @@ PianoControl::PianoControl(pp_int32 id,
 						   pp_uint8 numNotes,
 						   bool border/*= true*/) :
 	PPControl(id, parentScreen, eventListener, location, size),
-	border(border),
 	NUMNOTES(numNotes),
+	border(border),
+	ourOwnBorderColor(),
 	borderColor(&ourOwnBorderColor),
-	mode(ModeEdit)
+	hScrollbar(NULL),
+	caughtControl(NULL),
+	controlCaughtByLMouseButton(false), controlCaughtByRMouseButton(false),
+	startPos(0),
+	visibleWidth(size.width - 2),
+	visibleHeight(size.height - SCROLLBARWIDTH - 2),
+	sampleIndex(0),
+	mode(ModeEdit),
+	currentSelectedNote(0)
 {
 	// default color
 	ourOwnBorderColor.set(192, 192, 192);
@@ -126,22 +135,12 @@ PianoControl::PianoControl(pp_int32 id,
 	xMax = XMAX()*xscale;
 	yMax = YMAX()*yscale;
 
-	visibleWidth = size.width - 2;
-	visibleHeight = size.height - SCROLLBARWIDTH - 2;
-
 	adjustScrollbars();
-	
-	startPos = 0;
-	
-	caughtControl = NULL;	
-	controlCaughtByLMouseButton = controlCaughtByRMouseButton = false;
-
+		
 	nbu = new pp_uint8[NUMNOTES];
 	memset(nbu, 0, NUMNOTES);
 
 	keyState = new KeyState[NUMNOTES];
-
-	sampleIndex = 0;
 }
 
 PianoControl::~PianoControl()


### PR DESCRIPTION
I moved as much initialization as I could from constructor bodies into initializer lists, because I feel it's easier to track a single list of field initializers, than having to read two separate lists to see if a given field is initialized. I'm not sure if this was the best decision, because long initializer lists are ugly.

I ran MilkyTracker in ubsan, and found invalid bool accesses in these two structs. I initialized all fields I could find (though I might've missed some), instead of looking through control flow to see which fields were used or not. I don't like fields like `PatternEditorControl::visibleWidth` which are uninitialized until you call a method like `PatternEditorControl::setSize()` to set them, meaning the class isn't safe to use after the constructor, but only safe after calling methods.

I would *very much* prefer switching to C++11, which allows setting default values in the class declaration itself, so for most fields (which don't depend on the constructor), you don't have to match up the constructor with the class declaration to ensure all fields are initialized.

The result is clean in UBSAN, though I'm planning to perform more testing in valgrind, which is better at catching uninitialized memory usages than ASAN and UBSAN combined, to see if I missed any fields or any other classes with uninitialized memory.

See #251.