### PR TITLE
fix segfault when passing invalid filename on command line

### DIFF
--- a/src/tracker/sdl/SDL_Main.cpp
+++ b/src/tracker/sdl/SDL_Main.cpp
@@ -973,7 +973,10 @@ unrecognizedCommandLineSwitch:
 	if (loadFile)
 	{
 		struct stat statBuf;
-		if(stat(loadFile, &statBuf)) fprintf(stderr, "could not open %s: %s\n", loadFile, strerror(errno));
+		if (stat(loadFile, &statBuf) != 0)
+		{
+			fprintf(stderr, "could not open %s: %s\n", loadFile, strerror(errno));
+		}
 		else
 		{
 			PPSystemString newCwd = path.getCurrent();

--- a/src/tracker/sdl/SDL_Main.cpp
+++ b/src/tracker/sdl/SDL_Main.cpp
@@ -65,6 +65,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <limits.h>
+#include <errno.h>
 
 #include <SDL.h>
 #include "SDL_KeyTranslation.h"
@@ -971,13 +972,18 @@ unrecognizedCommandLineSwitch:
 
 	if (loadFile)
 	{
-		PPSystemString newCwd = path.getCurrent();
-		path.change(oldCwd);
-		SendFile(realpath(loadFile, loadFileAbsPath));
-		path.change(newCwd);
-		pp_uint16 chr[3] = {VK_RETURN, 0, 0};
-		PPEvent event(eKeyDown, &chr, sizeof(chr));
-		RaiseEventSerialized(&event);
+		struct stat statBuf;
+		if(stat(loadFile, &statBuf)) fprintf(stderr, "could not open %s: %s\n", loadFile, strerror(errno));
+		else
+		{
+			PPSystemString newCwd = path.getCurrent();
+			path.change(oldCwd);
+			SendFile(realpath(loadFile, loadFileAbsPath));
+			path.change(newCwd);
+			pp_uint16 chr[3] = {VK_RETURN, 0, 0};
+			PPEvent event(eKeyDown, &chr, sizeof(chr));
+			RaiseEventSerialized(&event);
+		}
 	}
 
 	// Main event loop


### PR DESCRIPTION
quick and dirty fix to issue where milkytracker did not check for the presence of a file before attempting to load it (for example, when doing `milkytracker ''`)