### PR TITLE
Added some shortcuts to make my performances easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ resources/pictures/docicons/osx/docerator/
 
 # Editor config files
 .vscode/
+.vs/

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -764,27 +764,27 @@
 				<td>Enter key-off (OS X only)</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Plus or Ctrl-K</em></td>
+				<td><em>Alt-Plus or Shift-J</em></td>
 				<td>Increase Add value</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Minus or Ctrl-J </em></td>
+				<td><em>Alt-Minus or Shift-H </em></td>
 				<td>Decrease Add value</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-N</em></td>
+				<td><em>Ctrl-J</em></td>
 				<td>Increase BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-B</em></td>
+				<td><em>Ctrl-H</em></td>
 				<td>Decrease BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-N</em></td>
+				<td><em>Ctrl-K</em></td>
 				<td>Increase BPM by 5</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-B</em></td>
+				<td><em>Ctrl-G</em></td>
 				<td>Decrease BPM by 5</td>
 			</tr>
 			<tr>

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -627,145 +627,169 @@
 		</table>
 		<h4>Pattern Editor:</h4>
 		<table>
-			<tr >
+			<tr>
 				<td><em>Cursor keys</em></td>
 				<td>Move around</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Tab</em></td>
 				<td>Jump to next channel</td>
 			</tr>
-			<tr >
+			<tr>
+				<td><em>Ctrl-Tab</em></td>
+				<td>Jump to previous channel</td>
+			</tr>
+			<tr>
 				<td><em>PageUp</em></td>
 				<td>Jump 16 rows up</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>PageDown</em></td>
 				<td>Jump 16 rows down</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Home</em></td>
 				<td>Jump to first row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>End</em></td>
 				<td>Jump to last row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F9</em></td>
 				<td>Jump to beginning of the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F10</em></td>
 				<td>Jump to position &frac14; through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F11</em></td>
 				<td>Jump to position halfway through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F12</em></td>
 				<td>Jump to position &frac34; through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Z</em></td>
 				<td>Undo</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Y</em></td>
 				<td>Redo</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Cursor keys</em></td>
 				<td>Select block</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Alt-Cursor keys</em></td>
 				<td>Extend block</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-A</em></td>
 				<td>Select entire pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-X</em></td>
 				<td>Cut</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-C</em></td>
 				<td>Copy</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-V</em></td>
 				<td>Paste</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Shift-V</em></td>
 				<td>Convert current pattern to sample</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-I</em></td>
 				<td>Interpolate values</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Delete</em></td>
 				<td>Delete note/instrument/volume/effect/parameter</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Del</em></td>
 				<td>Delete note, volume and effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Del</em></td>
 				<td>Delete volume and effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Alt-Delete</em></td>
 				<td>Delete effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Insert</em></td>
 				<td>Insert space on current track at cursor position</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Insert</em></td>
 				<td>Insert row at cursor position</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Alt-Backspace</em></td>
 				<td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Alt-Backspace</em></td>
 				<td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Backspace</em></td>
 				<td>Delete previous note</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Backspace</em></td>
 				<td>Delete previous row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>The key right of LShift</em></td>
 				<td>Enter key-off</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>The key below Esc</em></td>
 				<td>Enter key-off (Windows only)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>1</em></td>
 				<td>Enter key-off (OS X only)</td>
 			</tr>
-			<tr >
-				<td><em>Alt-Minus</em></td>
+			<tr>
+				<td><em>Alt-Plus or Ctrl-J</em></td>
 				<td>Increase Add value</td>
 			</tr>
-			<tr >
-				<td><em>or Alt-Plus</em></td>
+			<tr>
+				<td><em>Alt-Minus or Ctrl-Shift-J </em></td>
 				<td>Decrease Add value</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-[</em></td>
+				<td>Increase BPM by 1</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-]</em></td>
+				<td>Decrease BPM by 1</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-Shift-[</em></td>
+				<td>Increase BPM by 5</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-Shift-]</em></td>
+				<td>Decrease BPM by 5</td>
+			</tr>
+			<tr>
+				<td><em>Alt-I</em></td>
+				<td>Load Instrument (current slot)</td>
 			</tr>
 		</table>
 		<h4>Transpose:</h4>

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -764,27 +764,27 @@
 				<td>Enter key-off (OS X only)</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Plus or Ctrl-J</em></td>
+				<td><em>Alt-Plus or Ctrl-K</em></td>
 				<td>Increase Add value</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Minus or Ctrl-Shift-J </em></td>
+				<td><em>Alt-Minus or Ctrl-J </em></td>
 				<td>Decrease Add value</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-[</em></td>
+				<td><em>Ctrl-N</em></td>
 				<td>Increase BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-]</em></td>
+				<td><em>Ctrl-B</em></td>
 				<td>Decrease BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-[</em></td>
+				<td><em>Ctrl-Shift-N</em></td>
 				<td>Increase BPM by 5</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-]</em></td>
+				<td><em>Ctrl-Shift-B</em></td>
 				<td>Decrease BPM by 5</td>
 			</tr>
 			<tr>

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -48,6 +48,7 @@ void PatternEditorControl::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, 0, &PatternEditorControl::eventKeyDownBinding_NextChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_NextChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierSHIFT|KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DELETE, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_DeleteNoteVolumeAndEffect);

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -582,6 +582,14 @@ private:
 
 	void eventKeyDownBinding_InvokePatternCapture();
 
+	// brujo sauce
+	void eventKeyDownBinding_BpmPlus();
+	void eventKeyDownBinding_BpmMinus();
+	void eventKeyDownBinding_CoarseBpmPlus();
+	void eventKeyDownBinding_CoarseBpmMinus();
+	void eventKeyDownBinding_AddPlus();
+	void eventKeyDownBinding_AddMinus(); 
+	void eventKeyDownBinding_LoadInstrument();
 
 private:
 	// - friend classes --------------------------------------------------------

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -154,7 +154,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F7, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockDown);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F8, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockUp);
 
-	//eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD1, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD2, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD3, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -154,7 +154,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F7, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockDown);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F8, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockUp);
 
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
+	//eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD1, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD2, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD3, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
@@ -173,6 +173,15 @@ void Tracker::initKeyBindings()
 
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
+	// brujo's secret sauce 
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
+	// TODO: sequencer controls
 
 	// Key-down bindings for Fasttracker
 	// tab stuff
@@ -267,6 +276,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsFastTracker->addBinding('V', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	eventKeyDownBindings = eventKeyDownBindingsMilkyTracker;
+
 }
 
 void Tracker::eventKeyDownBinding_OpenTab()
@@ -1021,4 +1031,55 @@ void Tracker::eventKeyDownBinding_InvokePatternCapture()
 	sectionHDRecorder->toOrder = getOrderListBoxIndex();
   sectionHDRecorder->setSettingsAllowMuting(true);
 	sectionHDRecorder->exportWAVAsSample();
+}
+
+// brujo sauce definitions
+void Tracker::eventKeyDownBinding_BpmPlus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm + 1, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_BpmMinus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm - 1, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_CoarseBpmPlus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm + 5, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_CoarseBpmMinus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm - 5, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_AddPlus() {
+	getPatternEditorControl()->increaseRowInsertAdd();
+	updatePatternAddAndOctave();
+}
+
+void Tracker::eventKeyDownBinding_AddMinus() {
+	getPatternEditorControl()->decreaseRowInsertAdd();
+	updatePatternAddAndOctave();
+}
+
+void Tracker::eventKeyDownBinding_LoadInstrument() {
+	loadTypeWithDialog(FileTypes::FileTypeSongAllInstruments);
 }

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -174,12 +174,12 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	// brujo's secret sauce 
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddMinus);
 	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
 	// TODO: sequencer controls
 

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -174,12 +174,12 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	// brujo's secret sauce 
-	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('H', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('G', KeyModifierCTRL, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('H', KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
 	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
 	// TODO: sequencer controls
 


### PR DESCRIPTION
Hello! 

I'm trying to use MilkyTracker as a music performance tool with a tiny bluetooth keyboard.

However, this means that using a mouse to click buttons on the screen isn't super practical. 

I've added a few shortcuts so far, but plan to possibly add more. Also, there were a few that didn't work on Windows (like Alt-Tab to switch to previous column) so I added alternatives

Tested on Windows 10.