### PR TITLE
added sample-editor scripting feature

### DIFF
--- a/src/ppui/ContextMenu.cpp
+++ b/src/ppui/ContextMenu.cpp
@@ -375,4 +375,3 @@ void PPContextMenu::setLocation(const PPPoint& location)
 
 	this->location = loc;
 }
-

--- a/src/ppui/ContextMenu.h
+++ b/src/ppui/ContextMenu.h
@@ -101,6 +101,9 @@ public:
 	
 	void setNotifyParentOnHide(bool notifyParentOnHide) { this->notifyParentOnHide = notifyParentOnHide; }
 	bool getNotifyParentOnHide() const { return notifyParentOnHide; }
+
+	void empty(){ menu->items.clear(); }
+
 };
 
 #endif

--- a/src/tracker/FilterParameters.h
+++ b/src/tracker/FilterParameters.h
@@ -38,6 +38,7 @@ public:
 	{
 		float floatPart;
 		pp_int32 intPart;
+		char *stringPart;
 		
 		Parameter()
 		{
@@ -56,6 +57,10 @@ public:
 
 		explicit Parameter(pp_int32 value) :
 			intPart(value)
+		{
+		}
+		explicit Parameter(char *value) :
+			stringPart(value)
 		{
 		}
 	};

--- a/src/tracker/SampleEditor.cpp
+++ b/src/tracker/SampleEditor.cpp
@@ -36,6 +36,7 @@
 #include "EQConstants.h"
 #include "FilterParameters.h"
 #include "SampleEditorResampler.h"
+#include "ControlIDs.h"
 
 SampleEditor::ClipBoard::ClipBoard() :
 		buffer(NULL)
@@ -3132,4 +3133,3 @@ pp_uint32 SampleEditor::convertSmpPosToMillis(pp_uint32 pos, pp_int32 relativeNo
 	
 	return (pp_uint32)(((double)pos / c4spd) * 1000.0);
 }
-

--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -119,9 +119,6 @@ private:
 
 	bool drawing;
 	pp_int32 lastSamplePos;
-
-	void prepareUndo();
-	void finishUndo();
 	
 	bool revoke(const SampleUndoStackEntry* stackEntry);
 	
@@ -314,9 +311,11 @@ private:
 	TFilterFunc lastFilterFunc;
 		
 	void preFilter(TFilterFunc filterFuncPtr, const FilterParameters* par);
-	void postFilter();
 	
 public: 
+	void postFilter();
+	void prepareUndo();
+	void finishUndo();
 	void tool_newSample(const FilterParameters* par);
 	void tool_minimizeSample(const FilterParameters* par);
 	void tool_cropSample(const FilterParameters* par);

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -25,6 +25,7 @@
 #include "GraphicsAbstract.h"
 #include "PPUIConfig.h"
 #include "ScrollBar.h"
+#include "PPOpenPanel.h"
 #include "ContextMenu.h"
 #include "Piano.h"
 #include "Tools.h"
@@ -33,6 +34,13 @@
 #include "TrackerConfig.h"
 #include "PlayerController.h"
 #include "DialogBase.h"
+#include "FilterParameters.h"
+#include "ModuleEditor.h"
+#include "Scripting.h"
+#include "PPSystem.h"
+#include "ControlIDs.h"
+#include "SectionSamples.h"
+#include "TrackerSettingsDatabase.h"
 
 #include <algorithm>
 #include <math.h>
@@ -79,7 +87,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	
 	selectionStartNew(-1),
 	selectionEndNew(-1),
-
+	subMenuScripting(NULL),
 	selecting(-1),
 	resizing(0),
 	drawMode(false),
@@ -104,7 +112,7 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	scrollDist = (3298*visibleWidth) >> 16;
 	
 	adjustScrollbars();
-
+	
 	showMarks = new ShowMark[TrackerConfig::maximumPlayerChannels];
 	for (pp_int32 i = 0; i < TrackerConfig::maximumPlayerChannels; i++)
 	{
@@ -163,7 +171,11 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	subMenuGenerators->addEntry("Half Sine" PPSTR_PERIODS, MenuCommandIDGenerateHalfSine);
 	subMenuGenerators->addEntry("Absolute Sine" PPSTR_PERIODS, MenuCommandIDGenerateAbsoluteSine);
 	subMenuGenerators->addEntry("Silence" PPSTR_PERIODS, MenuCommandIDGenerateSilence);
-	
+
+	// scripting menu
+	subMenuScripting = new PPContextMenu(8, parentScreen, this, PPPoint(0, 0), TrackerConfig::colorThemeMain);
+	loadScriptsContextMenu();
+
 	// build context menu
 	editMenuControl = new PPContextMenu(4, parentScreen, this, PPPoint(0,0), TrackerConfig::colorThemeMain, true);
 	editMenuControl->addEntry("New" PPSTR_PERIODS, MenuCommandIDNew);
@@ -178,10 +190,12 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	editMenuControl->addEntry("Range all", MenuCommandIDSelectAll);
 	editMenuControl->addEntry("Loop range", MenuCommandIDLoopRange);
 	editMenuControl->addEntry(seperatorStringMed, -1);
-	editMenuControl->addEntry("Advanced   \x10", 0xFFFF, subMenuAdvanced);
-	editMenuControl->addEntry("Ext. Paste \x10", 0xFFFF, subMenuXPaste);
-	editMenuControl->addEntry("Protracker \x10", 0xFFFF, subMenuPT);
-	editMenuControl->addEntry("Generators \x10", 0xFFFF, subMenuGenerators);
+	editMenuControl->addEntry("Scripts      \x10", 0xFFFF, subMenuScripting );
+	editMenuControl->addEntry(seperatorStringMed, -1);
+	editMenuControl->addEntry("Advanced     \x10", 0xFFFF, subMenuAdvanced);
+	editMenuControl->addEntry("Ext. Paste   \x10", 0xFFFF, subMenuXPaste);
+	editMenuControl->addEntry("Protracker   \x10", 0xFFFF, subMenuPT);
+	editMenuControl->addEntry("Generators   \x10", 0xFFFF, subMenuGenerators);
 
 	// Create tool handler responder
 	toolHandlerResponder = new ToolHandlerResponder(*this);
@@ -209,6 +223,7 @@ SampleEditorControl::~SampleEditorControl()
 	delete subMenuXPaste;
 	delete subMenuPT;
 	delete subMenuGenerators;
+	delete subMenuScripting;
 }
 
 void SampleEditorControl::drawLoopMarker(PPGraphicsAbstract* g, pp_int32 x, pp_int32 y, bool down, const pp_int32 size)
@@ -1209,6 +1224,7 @@ pp_int32 SampleEditorControl::handleEvent(PPObject* sender, PPEvent* event)
 			 sender == reinterpret_cast<PPObject*>(subMenuAdvanced) ||
 			 sender == reinterpret_cast<PPObject*>(subMenuXPaste) ||
 			 sender == reinterpret_cast<PPObject*>(subMenuPT) ||
+			 sender == reinterpret_cast<PPObject*>(subMenuScripting) ||
 			 sender == reinterpret_cast<PPObject*>(subMenuGenerators)) &&
 			 event->getID() == eCommand)
 	{
@@ -1719,6 +1735,14 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	subMenuGenerators->setState(MenuCommandIDGenerateAbsoluteSine, isEmptySample);
 	subMenuGenerators->setState(MenuCommandIDGenerateSilence, isEmptySample);
 
+	// load items from scripts.txt if any
+	PPDictionaryKey *k = tracker->settingsDatabase->restore("SCRIPTSFILE");
+	if( k != NULL ) scriptsFile = PPString( k->getStringValue() );
+	if( scriptsFile.length() > 1 ){
+		Scripting::loadScripts(scriptsFile,&scriptsFolder);
+		loadScriptsContextMenu();
+	}
+
 	parentScreen->setContextMenuControl(editMenuControl);
 }
 
@@ -1908,6 +1932,10 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 			break;
 
 	}
+	if (commandId >= Scripting::MenuID)
+	{
+		executeScriptContextMenu( commandId );
+	}
 }
 
 void SampleEditorControl::editorNotification(EditorBase* sender, EditorBase::EditorNotifications notification)
@@ -2031,4 +2059,87 @@ void SampleEditorControl::editorNotification(EditorBase* sender, EditorBase::Edi
 		case EditorBase::NotificationUnprepareCritical:
 			break;
 	}
+}
+
+void SampleEditorControl::loadScriptsContextMenu(){
+	subMenuScripting->empty();
+	subMenuScripting->addEntry("Load" PPSTR_PERIODS, Scripting::MenuIDScriptBrowse);
+	Scripting::loadScripts( scriptsFile.getStrBuffer(), &scriptsFolder );
+	if( Scripting::scripts != NULL ){
+		static const char* seperatorStringLarge = "\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4\xc4";
+		subMenuScripting->addEntry(seperatorStringLarge, -1);
+		Scripting::loadScriptsToMenu(subMenuScripting);
+	}
+}
+
+void SampleEditorControl::executeScriptContextMenu(int commandId){
+	char cmd[255];
+	int selected_instrument;
+	int selected_sample;
+	PPString selected;
+
+	if (commandId == Scripting::MenuIDScriptBrowse)
+	{
+		#if defined(WINDOWS) || defined(WIN32) // C++ >= v17
+		AllocConsole();				   // popup console for errors
+		HWND hwnd = ::GetConsoleWindow();
+		if (hwnd != NULL){ // prevent user from closing console (thus milkytracker)
+			HMENU hMenu = ::GetSystemMenu(hwnd, FALSE);
+			if (hMenu != NULL) DeleteMenu(hMenu, SC_CLOSE, MF_BYCOMMAND);
+		}
+		freopen("conin$", "r", stdin);
+		freopen("conout$", "w", stdout);
+		freopen("conout$", "w", stderr);
+		#endif
+		if( scriptsFile.length() == 0 ){
+			printf("script: engine started\n");
+			printf("script: to download example scripts see: https://github.com/coderofsalvation/MilkyTrackerX\n");
+		}
+		Scripting::filepicker("Load script (or scripts.txt)",NULL,&scriptsFile, tracker->screen);
+		PPString fileshort = scriptsFile.stripPath();
+		if( fileshort.compareTo( "scripts.txt") == 0 ){
+			Scripting::loadScripts( scriptsFile.getStrBuffer(), &scriptsFolder );
+			loadScriptsContextMenu();
+			tracker->settingsDatabase->store("SCRIPTSFILE",scriptsFile);
+			return tracker->showMessageBox(MESSAGEBOX_UNIVERSAL, "Scripts contextmenu was updated", Tracker::MessageBox_OK);
+		}else{
+			sprintf(cmd,"%s %%s %%s",scriptsFile.getStrBuffer());	
+			selected = scriptsFile.subString(0,24);
+			commandId = Scripting::MenuIDFile;
+		}
+	}
+
+	PPPath *currentPath = PPPathFactory::createPath();
+	PPString projectPath = currentPath->getCurrent();
+	if( scriptsFolder.length() != 0 ) currentPath->change(scriptsFolder);
+	tracker->getSelectedInstrument(&selected_instrument, &selected_sample);
+	PPString fin = "in.wav";   // ideally std::filesystem::temp_directory_path()) + string("\\in.wav") ?
+	PPString fout = "out.wav"; // TODO: write clipboard.wav
+	// save samples to local disk
+	tracker->getModuleEditor()->saveSample(
+		fin,
+		selected_instrument,
+		selected_sample,
+		ModuleEditor::SampleFormatTypeWAV);
+	tracker->getModuleEditor()->saveSample(
+		fout,
+		selected_instrument,
+		selected_sample,
+		ModuleEditor::SampleFormatTypeWAV);
+	sampleEditor->prepareUndo();
+	int ret = Scripting::runScriptMenuItem(scriptsFolder, commandId, cmd, tracker->screen, fin, fout, &selected);
+	if (ret != 0 && ret != -1)
+		return tracker->showMessageBox(MESSAGEBOX_UNIVERSAL, "script error :/", Tracker::MessageBox_OK);
+	tracker->getModuleEditor()->loadSample(
+		fout,
+		selected_instrument,
+		selected_sample,
+		ModuleEditor::SampleFormatTypeWAV);
+	tracker->getModuleEditor()->setSampleName(selected_instrument, selected_sample, selected.getStrBuffer(), selected.length() );
+	tracker->sectionSamples->updateAfterLoad();
+	rangeAll(true);
+	showAll();
+	sampleEditor->finishUndo();
+	sampleEditor->postFilter();
+	currentPath->change(projectPath); // restore
 }

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -71,6 +71,7 @@ private:
 	PPContextMenu* subMenuXPaste;
 	PPContextMenu* subMenuGenerators;
 	PPContextMenu* subMenuPT;
+	PPContextMenu* subMenuScripting;
 
 	// extent
 	pp_int32 selectionStartNew, selectionEndNew;
@@ -110,6 +111,9 @@ private:
 	pp_int32 relativeNote;
 	OffsetFormats offsetFormat;
 
+	PPString scriptsFile;
+	PPString scriptsFolder;
+
 	mp_sint32 getVisibleLength();
 	
 	float calcScale(mp_sint32 len);
@@ -147,6 +151,9 @@ public:
 
 	virtual void setSize(const PPSize& size);
 	virtual void setLocation(const PPPoint& location);
+
+	void loadScriptsContextMenu();
+	void executeScriptContextMenu(int commandId);
 
 public:
 	// controlling editor from outside

--- a/src/tracker/SampleEditorControlLastValues.h
+++ b/src/tracker/SampleEditorControlLastValues.h
@@ -48,6 +48,10 @@ struct SampleEditorControlLastValues
 	pp_int32 resampleInterpolationType;
 	bool adjustFtAndRelnote;
 	bool adjustSampleOffsetCommand;
+
+  PPString csoundFile;
+  PPString csoundIn;
+  PPString csoundOut;
 	
 	static float invalidFloatValue() 
 	{
@@ -74,6 +78,9 @@ struct SampleEditorControlLastValues
 		resampleInterpolationType = invalidIntValue();
 		adjustFtAndRelnote = true;
 		adjustSampleOffsetCommand = false;
+    csoundFile = "";
+    csoundIn = "";
+    csoundOut = "";
 	}
 		
 	PPDictionary convertToDictionary()

--- a/src/tracker/Scripting.h
+++ b/src/tracker/Scripting.h
@@ -1,0 +1,139 @@
+/*
+ *  tracker/ScopesControl.h
+ *
+ *  Copyright 2022 Coderofsalvation / Leon van Kammen 
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  Scripting.h
+ *  A simple scripting-bridge for MilkyTracker SampleEditor
+ *  Instead of bloating milkytracker with more effects/plugins, the burden of maintenance is reversed: external 
+ *  applications & scripts can 'hook' into the sample-editor using the 'Script'-contextmenu.
+ * 
+ *  Created by coderofsalvation / Leon van Kammen on 26-10-2022 
+ */
+
+#ifndef SCRIPT_H
+#define SCRIPT_H
+
+#include "Tracker.h"
+#include "ModuleEditor.h"
+#include "PPUI.h"
+#include "DialogBase.h"
+#include "PPPathFactory.h"
+
+/*
+ * a list of scripting backends can be defined by 
+ * the enduser (using the configfile below)
+ */
+
+#define SCRIPTS_MAX 75
+#define SCRIPTS_TOKENS 3
+#define SCRIPTS_FORMAT "%[^';'];%[^'|']|%[^'\n']\n"
+//                      <name>;<cmd fmstring>|<exec|extension_for_filedialog>\n
+
+// default example scripts (console will warn if dependencies are not installed)
+// more scripts can be found here: https://gitlab.com/coderofsalvation/milkytracker-scripts
+
+class Scripting{
+	public:
+
+		static const int MenuID             = 10000;
+		static const int MenuIDFile         = MenuID-1;
+		static const int MenuIDScriptBrowse = MenuID+SCRIPTS_MAX;
+		static FILE *scripts;
+
+		static void loadScripts( PPString scriptsFile, PPString *scriptsFolder ){
+			if( scripts != NULL ) fclose(scripts);
+			scripts = fopen( scriptsFile.getStrBuffer(), "r");
+			if( scripts == NULL ) printf("error: could not open %s",scriptsFile.getStrBuffer());
+			scriptsFolder->replace(scriptsFile);
+			PPString path = scriptsFolder->stripPath();
+			scriptsFolder->deleteAt( scriptsFolder->length()-path.length()-1, path.length()+1 );
+		}
+
+		static void loadScriptsToMenu( PPContextMenu *m ){
+			if( scripts == NULL ) return;
+			// # <name>;<binary>;<cmd>;<exec|extension_for_filedialog>\n
+			char name[100], cmd[255], ext[20];
+			int  i = 0;
+			rewind(scripts);
+			while( fscanf(scripts, SCRIPTS_FORMAT, name, cmd, ext) == SCRIPTS_TOKENS && i < SCRIPTS_MAX ){
+				m->addEntry( name, MenuID+i);
+				i++;
+			}
+		}
+
+		static int runScriptMenuItem(PPString cwd, int ID, char *cmd, PPScreen *screen, PPString fin, PPString fout, PPString *selectedName ){
+			int  i = 0;
+			char name[100], ext[20];
+			PPString selectedFile;
+			if( ID == Scripting::MenuIDFile ){
+				// run selected script from filepicker
+				return runScript(cwd,cmd,screen,fin,fout,selectedFile);
+			}else{ 
+				// run menu shortcut item from scripts.txt
+				rewind(scripts);
+				while( fscanf(scripts, SCRIPTS_FORMAT, name, cmd, ext) == SCRIPTS_TOKENS && i < SCRIPTS_MAX ){
+					if( MenuID+i == ID ){ 
+						if( strncmp("exec",ext,4) != 0 ) filepicker(name,ext,&selectedFile,screen);
+						*selectedName = PPString(name).subString(0,24);
+						return runScript(cwd,cmd,screen,fin,fout,selectedFile);
+					}
+					i++;
+				}
+			}
+			return -1;
+		}
+
+		static int runScript(PPString cwd, char *cmd, PPScreen *screen, PPString fin, PPString fout, PPString file ){
+			char finalcmd[255];
+			PPString fclipboard;
+			PPPath *currentPath = PPPathFactory::createPath();
+			currentPath->change(cwd);
+			sprintf(finalcmd, cmd,  fin.getStrBuffer(),
+									fout.getStrBuffer(),
+									fclipboard.getStrBuffer(),
+									file.getStrBuffer() );
+			printf("> %s\n",finalcmd);
+			return system(finalcmd);
+		}
+
+		static void filepicker(char *name, char *ext, PPString *result, PPScreen *screen ){
+			PPOpenPanel* openPanel = NULL;
+			const char *extensions[] = {
+				ext,name,
+				NULL,NULL
+			};
+			openPanel = new PPOpenPanel(screen, name );
+			openPanel->addExtensions(extensions);
+			if (!openPanel) return;
+			bool res = true;
+			if (openPanel->runModal() == PPModalDialog::ReturnCodeOK)
+			{
+				*result = openPanel->getFileName();
+				delete openPanel;
+			}
+		}
+};
+
+FILE* Scripting::scripts              = NULL;
+
+#endif
+

--- a/src/tracker/Tracker.cpp
+++ b/src/tracker/Tracker.cpp
@@ -3225,3 +3225,7 @@ void Tracker::signalWaitState(bool b)
 	screen->signalWaitState(b, TrackerConfig::colorThemeMain);	
 }
 
+void Tracker::getSelectedInstrument( int *instrument, int *sample ) {
+	*instrument = listBoxInstruments->getSelectedIndex();
+	*sample = listBoxSamples->getSelectedIndex();
+}

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -462,6 +462,8 @@ public:
 
 	void sendNoteDown(pp_int32 note, pp_int32 volume = -1);
 	void sendNoteUp(pp_int32 note);
+  void getSelectedInstrument( int *instrument, int *sample );
+  ModuleEditor* getModuleEditor(){ return moduleEditor; }
 
 private:
 	void switchEditMode(EditModes mode);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/180068/186959705-26f6948b-adf9-418b-80aa-45d6d410d37e.png)

A simple scripting-bridge for MilkyTracker SampleEditor
Instead of bloating milkytracker with more effects/plugins, the burden of maintenance is reversed: external 
applications & scripts can 'hook' into the sample-editor using the 'Script'-contextmenu.

## DEMO video

https://drive.google.com/file/d/1dG_vmeCFSbmhLlnlHpgcLNB6zScXXTng/view?usp=sharing

## Usecases

* generate samples using puredata/csound or your favorite wave-editor etc
* dump gig/sf2-soundfont wave-files into directory
* write custom SAMPLERS: sample ANY SYNTH/APP/INPUT into milkytracker
* apply a complex effect to a sample
* automate tedious tasks
* use your favorite scripting language to automate things 
* Create script-pipelines between different tools / commands, pick random samples from folders etc.



example scripting: https://gitlab.com/coderofsalvation/milkytracker-scripts