### PR TITLE
show channel meters & low/high energy channels for better mix-crafting

### DIFF
--- a/src/tracker/ScopesControl.cpp
+++ b/src/tracker/ScopesControl.cpp
@@ -134,6 +134,8 @@ private:
 	pp_int32 lasty, lastx;
 
 public:
+	float peak;
+	pp_int32 max;
 	ScopePainter(PPGraphicsAbstract* g, pp_uint32 count, pp_uint32 channelHeight,
 				 const PPColor& scopebColor, const PPColor& scopedColor,
 				 pp_int32 locx, pp_int32 locy,
@@ -146,6 +148,8 @@ public:
 		locx(locx), locy(locy),
 		appearance(appearance),
 		flipped(false),
+    	max(0),
+    	peak(0.0),
 		counter(0), flipCounter(0), flipCounterStep(1)
 	{
 		count2 = count - 3;
@@ -166,6 +170,10 @@ public:
 	virtual void fetchSampleData(mp_sint32 sample)
 	{
 		const pp_int32 y = (((-sample >> 10)*(signed)channelHeight)>>6) + locy;
+		if( abs(sample) > max ){
+			max = abs(sample);
+			peak = (float)max;
+		}
 
 		g->setSafeColor(sr>>16, sg>>16, sb>>16);
 		sr+=addr; sg+=addg; sb+=addb;
@@ -357,9 +365,11 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 
 		pp_int32 sy2 = locy + channelHeight / 2 - smallFont->getCharHeight() - 1;
 
+    ScopePainter scopePainter(g, count, channelHeight, scopebColor, scopedColor, locx, locy, appearance);
+    float vumax = 24000.0;
+
 		if (!muteChannels[c])
 		{
-			ScopePainter scopePainter(g, count, channelHeight, scopebColor, scopedColor, locx, locy, appearance);
 
 			if (enabled)
 				playerController->grabSampleData(c, count, 160, scopePainter);
@@ -386,6 +396,20 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 			g->setColor(col);
 #endif
 			locx = scopePainter.getLocx();
+
+			// draw vu channelmeters
+			pp_int32 vu = scopePainter.max * (float)channelHeight/vumax; 
+			pp_int32 peak = (pp_int32)(scopePainter.peak * (float)channelHeight/vumax);
+			pp_int32 vx = channelRects[c].x1+3;
+      		// discriminate between high/low-energy channels (peaking vs non-peaking channels) for better mixing-feedback
+			g->setColor( scopePainter.peak > (vumax/2.0) ? TrackerConfig::colorScopes : TrackerConfig::colorThemeMain);
+			g->drawVLine(channelRects[c].y2-vu ,channelRects[c].y2, vx);
+			g->drawVLine(channelRects[c].y2-vu,channelRects[c].y2, vx+1);
+			g->drawVLine(channelRects[c].y2-vu,channelRects[c].y2, vx+2);
+			g->drawVLine(channelRects[c].y2-vu,channelRects[c].y2, vx+3);
+			g->setColor( TrackerConfig::colorSampleEditorWaveform );
+			g->drawHLine(vx, vx+4, channelRects[c].y2-vu-2);
+			g->drawHLine(vx, vx+4, channelRects[c].y2-vu-3);
 		}
 		else
 		{
@@ -416,7 +440,7 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 		g->setFont((channelWidth < 40 || wrapped) ? smallFont : font);
 		g->setColor(0, 0, 0);
 		g->drawString(buffer, sx+1, sy+1);
-		g->setColor(foregroundColor);
+		g->setColor( foregroundColor );
 		g->drawString(buffer, sx, sy);
 
 		if (cn == 0)


### PR DESCRIPTION
![peak](https://user-images.githubusercontent.com/180068/187203840-0c5d6a73-867b-4341-bcec-ff61f45b65a4.gif)

The scopes are nice, but this shows what the channels are doing in a more familiar mixing-desk-meter-way.
It also shows which channels are high energy (usually drums) by painting the meter with either scope- or highlighted-color.
That way, if the master vumeter peaks, you can look at the highlighted channelmeters (channel 4) in order to know which notes/samples to lower in volume/eq etc, to get that sausage-perfect mix without using dynamic-plugins.

# background

In modtrackers, triggering multiple samples on the same row,  easily accumulates in the mid-frequencies (becoming peaks), so it's almost guaranteed to end up with a 'weak'-sounding mix (unless careful eq'ing of samples).
The milkytracker master vumeter helps a lot while eq'ing samples, as well as the clipping indicator.
Fortunately these days the loudness wars have been replaced by better speakers, metering & eq'ing. (something which is all possible in milkytracker without becoming a pluginhost like renoise).
