### PR TITLE
bugfix to void rapidly retriggering sample during keyjazz sustain

### DIFF
--- a/src/tracker/RecorderLogic.cpp
+++ b/src/tracker/RecorderLogic.cpp
@@ -194,10 +194,10 @@ void RecorderLogic::sendNoteDownToPatternEditor(PPEvent* event, pp_int32 note, P
 				}
 				// if there is already a note playing on this channel
 				// we "cut" the note
-				//else if (keys[i].channel == chn)
-				//{
-				//	keys[i].note = keys[i].channel = 0;
-				//}
+				else if (keys[i].channel == chn)
+				{
+					keys[i].note = keys[i].channel = 0;
+				}
 			}
 			
 			// play it


### PR DESCRIPTION
I guess these lines were commented (but forgot to get uncommented) during https://github.com/milkytracker/MilkyTracker/commit/477e611b27c425857e636a7c1e0d89e8bb8b2817.

It resulted in a bug which retriggered a sample (which has a pingpong/forward loop set) rapidly (as soon as the end of the sample was reached).
If you test this with a looped pad-sample (and holding key 'q'), you'll notice that with this 'fix' the note now sustains properly (including looping).
I've tested the note-offs and they worked well too (so no regression), it's quite comfortable to play/records notes now.