### PR TITLE
responsive filedialog

### DIFF
--- a/src/ppui/DialogFileSelector.cpp
+++ b/src/ppui/DialogFileSelector.cpp
@@ -76,7 +76,9 @@ DialogFileSelector::DialogFileSelector(PPScreen* screen,
 	allowEditFileName(editfileName),
 	sortAscending(true)
 {
-	initDialog(screen, responder, id, caption, 310, 230, 26, "Ok", "Cancel");
+  	pp_int32 w = screen->getWidth() / 2;
+  	pp_int32 h = screen->getHeight() /2;
+	initDialog(screen, responder, id, caption, w < 500 ? w : 500, h < 800 ? h : 800, 26, "Ok", "Cancel");
 
 	PPControl* text = getMessageBoxContainer()->getControlByID(MESSAGEBOX_STATICTEXT_MAIN_CAPTION);
 	text->setLocation(PPPoint(text->getLocation().x, text->getLocation().y - 4));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/180068/187030570-475313f0-6be7-44df-bef1-003abfbe008c.png)

The width/height was hardcoded, and on a 22" screen this is quite claustrophobic.
This fix (see screenshot) will make it adapt to the screensize.
This is nice especially since samplepacks can be huge, and personal sample/instrument-directories can grow over time.
It caps to max 500x800 to prevent useless width-margins (or data overload in case of height) and still looks good on the smallest resolution:

![image](https://user-images.githubusercontent.com/180068/187030755-48d89bc4-3e19-42f5-b1c2-cbe0b6b50e3d.png)
