### PR TITLE
feature: mastering limiter

### DIFF
--- a/src/milkyplay/Limiter.h
+++ b/src/milkyplay/Limiter.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2022, The MilkyTracker Team.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#define ZEROCROSSING(a,b) (a >= 0.0 && b <= 0.0 || a <= 0.0 && b >= 0.0 )
+#define NUM_CHUNKS 16
+#define BUFFER_TIME 0.0053
+#define DB_CO(g) ((g) > -90.0f ? powf(10.0f, (g) * 0.05f) : 0.0f)
+#define CO_DB(v) (20.0f * log10f(v))
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+// ported awesome fastlookahead limiter by steve harris @ https://github.com/swh/ladspa
+struct Limiter : public Mixable
+{
+  float fmax;
+  mp_uint32 preset; // samplerate
+  mp_uint32 fs; // samplerate
+  mp_uint32 buffer_len; 
+  mp_uint32 buffer_len_orig; 
+  mp_uint32 buffer_pos; 
+  mp_uint32 delay; 
+  mp_uint32 chunk_pos; 
+  mp_uint32 chunk_num; 
+  mp_uint32 chunk_size; 
+  float peak;
+  float atten;
+  float atten_lp;
+  float delta;
+  float *buffer;
+  float *chunks;
+  float limit;
+  float release;
+  float ingain; // -20 .. 20 
+  float attenuation; // output gain 
+
+	Limiter() : 
+    fs(-1),
+    fmax(32678.0f),
+    limit(-0.05),
+    release(0.01),
+    buffer(NULL),
+    ingain(1.0),
+    attenuation(0.0)
+	{
+	}
+
+  void init(mp_uint32 s_rate, mp_uint32 buffersize){
+    cleanup();
+    fs = s_rate;
+    buffer_len = buffersize; 
+    buffer_len_orig = buffersize;
+    buffer_pos = 0;
+    /* Find size for power-of-two interleaved delay buffer */
+    while(buffer_len < fs * BUFFER_TIME * 2) {
+      buffer_len *= 2;
+    }
+    buffer = (float *)calloc(buffer_len, sizeof(float));
+    delay = (int)(0.005 * fs);
+    chunk_pos = 0;
+    chunk_num = 0;
+    /* find a chunk size (in smaples) thats roughly 0.5ms */
+    chunk_size = s_rate / 2000; 
+    chunks = (float *)calloc(NUM_CHUNKS, sizeof(float));
+    peak = 0.0f;
+    atten = 1.0f;
+    atten_lp = 1.0f;
+    delta = 0.0f;
+    memset(buffer, 0, NUM_CHUNKS * sizeof(float));    
+  }
+
+  void round_to_zero(volatile float *f){
+    *f += 1e-18;
+    *f -= 1e-18;
+  }
+
+  void cleanup(){
+    if( fs == -1 ) return;
+    free(buffer);
+    free(chunks);
+  }
+
+  void buffer_write( mp_sint32 *buffer, mp_uint32 pos, float max,float v){
+      round_to_zero(&v);
+      if (v < -max) v = -max;
+      else if (v > max) v = max;
+      buffer[pos] = (mp_sint32)(v*fmax);
+  }
+
+  virtual void mix(mp_sint32 *inbuffer, mp_uint32 sample_count)
+  {
+    unsigned long pos;
+    const float max = DB_CO(limit);
+    const float trim = DB_CO(ingain);
+    float sig;
+    unsigned int i;
+    mp_uint32 posL;
+    mp_uint32 posR;
+
+    if( fs == -1 || sample_count > buffer_len ) return; // protect
+    for (pos = 0; pos < sample_count; pos++)
+    {
+      posL = pos*2;
+      posR = posL+1;
+
+      if (chunk_pos++ == chunk_size)
+      {
+        /* we've got a full chunk */
+
+        delta = (1.0f - atten) / (fs * release);
+        round_to_zero(&delta);
+        for (i = 0; i < 10; i++)
+        {
+          const int p = (chunk_num - 9 + i) & (NUM_CHUNKS - 1);
+          const float this_delta = (max / chunks[p] - atten) /
+                                   ((float)(i + 1) * fs * 0.0005f + 1.0f);
+          if (this_delta < delta)
+          {
+            delta = this_delta;
+          }
+        }
+        chunks[chunk_num++ & (NUM_CHUNKS - 1)] = peak;
+        peak = 0.0f;
+        chunk_pos = 0;
+      }
+
+      float in_1 = (float)inbuffer[posL]*(1.0/fmax);
+      float in_2 = (float)inbuffer[posR]*(1.0/fmax);
+
+      buffer[(buffer_pos * 2) & (buffer_len - 1)]     = in_1 * trim + 1.0e-30;
+      buffer[(buffer_pos * 2 + 1) & (buffer_len - 1)] = in_2 * trim + 1.0e-30;
+
+      sig = fabs(in_1) > fabs(in_2) ? fabs(in_1) : fabs(in_2);
+      sig += 1.0e-30;
+      if (sig * trim > peak)
+      {
+        peak = sig * trim;
+      }
+      // round_to_zero(&peak);
+      // round_to_zero(&sig);
+      atten += delta;
+      atten_lp = atten * 0.1f + atten_lp * 0.9f;
+      // round_to_zero(&atten_lp);
+      if (delta > 0.0f && atten > 1.0f)
+      {
+        atten = 1.0f;
+        delta = 0.0f;
+      }
+
+      buffer_write(inbuffer,posL, max,buffer[(buffer_pos * 2 - delay * 2) &
+                                      (buffer_len - 1)] *
+                                   atten_lp);
+      buffer_write(inbuffer,posR, max,buffer[(buffer_pos * 2 - delay * 2 + 1) &
+                                      (buffer_len - 1)] *
+                                   atten_lp);
+      buffer_pos++;
+
+    }
+    buffer_pos = buffer_pos;
+    peak = peak;
+    atten = atten;
+    atten_lp = atten_lp;
+    chunk_pos = chunk_pos;
+    chunk_num = chunk_num;
+    //*(plugin_data->attenuation) = -CO_DB(atten);
+    //*(plugin_data->latency) = delay;
+  }
+};

--- a/src/milkyplay/MasterMixer.cpp
+++ b/src/milkyplay/MasterMixer.cpp
@@ -64,6 +64,7 @@ MasterMixer::MasterMixer(mp_uint32 sampleRate,
 	started(false),
 	paused(false)
 {
+	masteringLimiter.init(sampleRate,bufferSize);
 }
 
 MasterMixer::~MasterMixer()
@@ -208,6 +209,7 @@ mp_sint32 MasterMixer::setBufferSize(mp_uint32 bufferSize)
 		
 		notifyListener(MasterMixerNotificationBufferSizeChanged);
 	}
+	masteringLimiter.init(sampleRate,this->bufferSize);
 	return 0;
 }
 
@@ -223,6 +225,7 @@ mp_sint32 MasterMixer::setSampleRate(mp_uint32 sampleRate)
 
 		notifyListener(MasterMixerNotificationSampleRateChanged);
 	}
+	masteringLimiter.init(sampleRate,this->bufferSize);
 	return 0;
 }
 
@@ -403,6 +406,11 @@ void MasterMixer::mixerHandler(mp_sword* buffer)
 		{
 			device->mixable->mix(mixBuffer, bufferSize);
 		}
+	}
+
+	if( limiterDrive > 0 ){
+		masteringLimiter.ingain = float(30.0/10.0) * (float)limiterDrive;
+		masteringLimiter.mix(mixBuffer, bufferSize );
 	}
 	
 	if (!disableMixing)

--- a/src/milkyplay/MasterMixer.h
+++ b/src/milkyplay/MasterMixer.h
@@ -39,6 +39,7 @@
 #define __MASTERMIXER_H__
 
 #include "Mixable.h"
+#include "Limiter.h"
 
 class MasterMixer
 {
@@ -118,6 +119,8 @@ public:
 	
 	mp_sint32 getCurrentSample(mp_sint32 position, mp_sint32 channel);
 	mp_sint32 getCurrentSamplePeak(mp_sint32 position, mp_sint32 channel);	
+
+	void setLimiterDrive( mp_uint32 drive ){ this->limiterDrive = drive; }
 			
 private:
 	MasterMixerNotificationListener* listener;
@@ -128,6 +131,8 @@ private:
 	bool disableMixing;
 	mp_uint32 numDevices;
 	Mixable* filterHook;
+	mp_uint32 limiterDrive;
+	Limiter masteringLimiter;
 
 	struct DeviceDescriptor
 	{

--- a/src/milkyplay/PlayerGeneric.cpp
+++ b/src/milkyplay/PlayerGeneric.cpp
@@ -923,7 +923,8 @@ mp_sint32 PlayerGeneric::exportToWAV(const SYSCHAR* fileName, XModule* module,
 									 const mp_ubyte* mutingArray/* = NULL*/, mp_uint32 mutingNumChannels/* = 0*/,
 									 const mp_ubyte* customPanningTable/* = NULL*/,
 									 AudioDriverBase* preferredDriver/* = NULL*/,
-									 mp_sint32* timingLUT/* = NULL*/)
+									 mp_sint32* timingLUT/* = NULL*/,
+									 mp_uint32 limiterDrive /* = 0 */)
 {
 	PlayerBase* player = NULL;
 	
@@ -978,6 +979,7 @@ mp_sint32 PlayerGeneric::exportToWAV(const SYSCHAR* fileName, XModule* module,
 			for (mp_uint32 i = 0; i < mutingNumChannels; i++)
 				player->muteChannel(i, mutingArray[i] == 1);
 		}
+		mixer.setLimiterDrive(limiterDrive);
 		player->startPlaying(module, false, startOrder, 0, -1, customPanningTable, false, -1);
 		
 		mixer.start();

--- a/src/milkyplay/PlayerGeneric.h
+++ b/src/milkyplay/PlayerGeneric.h
@@ -103,6 +103,8 @@ private:
 	mp_sint32			panningSeparation;
 	// remember maximum amount of virtual channels
 	mp_sint32			numMaxVirChannels;
+	// remember mastering limiter
+	mp_uint32 			limiterDrive;
 
 	void				adjustSettings();
 
@@ -644,7 +646,8 @@ public:
 									const mp_ubyte* mutingArray = NULL, mp_uint32 mutingNumChannels = 0,
 									const mp_ubyte* customPanningTable = NULL,
 									AudioDriverBase* preferredDriver = NULL,
-									mp_sint32* timingLUT = NULL);
+									mp_sint32* timingLUT = NULL,
+									mp_uint32 limiterDrive = 0);
 	
 	/**
 	 * Grab current channel data from a module channel

--- a/src/ppui/Dictionary.cpp
+++ b/src/ppui/Dictionary.cpp
@@ -68,7 +68,7 @@ PPDictionaryKey* PPDictionary::getKeyToModify(const PPString& key) const
 	for (pp_int32 i = 0;  i < keys->size(); i++)
 	{
 		PPDictionaryKey* theKey = keys->get(i);
-		if (theKey->getKey().compareTo(key) == 0)
+		if (theKey != NULL && theKey->getKey().compareTo(key) == 0)
 			return theKey;
 	}
 	return NULL;

--- a/src/tracker/ModuleServices.cpp
+++ b/src/tracker/ModuleServices.cpp
@@ -59,7 +59,9 @@ pp_int32 ModuleServices::estimateMixerVolume(WAVWriterParameters& parameters,
 									   parameters.muting, 
 									   module.header.channum, 
 									   parameters.panning, 
-									   audioDriver);
+									   audioDriver,
+									   NULL,
+									   parameters.limiterDrive);
 	
 	if (numSamplesProgressed)
 		*numSamplesProgressed = res;
@@ -136,7 +138,9 @@ pp_int32 ModuleServices::exportToWAV(const PPSystemString& fileName, WAVWriterPa
 										  parameters.fromOrder, parameters.toOrder, 
 										  muting, 
 										  module.header.channum, 
-										  parameters.panning);
+										  parameters.panning,
+										  NULL,NULL,
+										  parameters.limiterDrive);
 			}
 		}
 		
@@ -148,7 +152,9 @@ pp_int32 ModuleServices::exportToWAV(const PPSystemString& fileName, WAVWriterPa
 								  parameters.fromOrder, parameters.toOrder, 
 								  parameters.muting, 
 								  module.header.channum, 
-								  parameters.panning);
+								  parameters.panning,
+								  NULL,NULL,
+								  parameters.limiterDrive);
 	}
 		
 	delete player;	
@@ -222,7 +228,6 @@ pp_int32 ModuleServices::exportToBuffer16Bit(WAVWriterParameters& parameters, pp
 											 pp_uint32 bufferSize, bool mono)
 {
 	PlayerGeneric* player = new PlayerGeneric(parameters.sampleRate);
-
 	player->setBufferSize(1024);
 	player->setPlayMode((PlayerGeneric::PlayModes)parameters.playMode);
 	player->setResamplerType((ChannelMixer::ResamplerTypes)parameters.resamplerType);
@@ -236,8 +241,9 @@ pp_int32 ModuleServices::exportToBuffer16Bit(WAVWriterParameters& parameters, pp
 									   parameters.muting, 
 									   module.header.channum, 
 									   parameters.panning,
-									   audioDriver);
-	
+									   audioDriver,
+									   NULL,
+									   parameters.limiterDrive);
 	delete player;	
 	return res;
 }

--- a/src/tracker/ModuleServices.h
+++ b/src/tracker/ModuleServices.h
@@ -64,6 +64,7 @@ public:
 		pp_uint32 toOrder;
 		const pp_uint8* muting;
 		const pp_uint8* panning;
+		pp_uint32 limiterDrive;
 		
 		bool multiTrack;
 		
@@ -77,7 +78,8 @@ public:
 			toOrder(0),
 			muting(NULL),
 			panning(NULL),
-			multiTrack(false)
+			multiTrack(false),
+			limiterDrive(0)
 		{
 		}
 	};

--- a/src/tracker/PlayerMaster.cpp
+++ b/src/tracker/PlayerMaster.cpp
@@ -68,7 +68,9 @@ void PlayerMaster::adjustSettings()
 
 		if (!player->isPlaying())
 			player->resumePlaying(false);
+
 	}
+	if( currentSettings.limiterDrive >= 0 ) mixer->setLimiterDrive( currentSettings.limiterDrive );
 }
 
 void PlayerMaster::applySettingsToPlayerController(PlayerController& playerController, const TMixerSettings& settings)
@@ -311,6 +313,9 @@ bool PlayerMaster::applyNewMixerSettings(const TMixerSettings& settings, bool al
 	
 	if (settings.mixerVolume >= 0)
 		currentSettings.mixerVolume = settings.mixerVolume;
+	
+	if (settings.limiterDrive >= 0)
+		currentSettings.limiterDrive = settings.limiterDrive;
 
 	if (settings.ramping >= 0)
 		currentSettings.ramping = settings.ramping;

--- a/src/tracker/PlayerMaster.h
+++ b/src/tracker/PlayerMaster.h
@@ -56,6 +56,8 @@ struct TMixerSettings
     pp_uint32 numPlayerChannels;
 	// 0 means disable virtual channels, negative value means ignore
 	pp_int32 numVirtualChannels;
+	// limiterDrive (negative value means ignore)
+	pp_int32 limiterDrive;
 
 	TMixerSettings() :
 		mixFreq(-1),
@@ -67,6 +69,7 @@ struct TMixerSettings
 		ramping(-1),
 		audioDriverName(NULL),
         numPlayerChannels(TrackerConfig::numPlayerChannels),
+		limiterDrive(-1),
 		numVirtualChannels(-1)
 	{
 	}
@@ -156,6 +159,8 @@ private:
 	
 	void adjustSettings();
 	void applySettingsToPlayerController(PlayerController& playerController, const TMixerSettings& settings);
+
+	pp_int32 limiterDrive;
 	
 public:
 	PlayerMaster(pp_uint32 numDevices = DefaultMaxDevices);

--- a/src/tracker/SectionHDRecorder.cpp
+++ b/src/tracker/SectionHDRecorder.cpp
@@ -53,6 +53,7 @@
 #include "PPSavePanel.h"
 
 #include "ControlIDs.h"
+#include "TrackerSettingsDatabase.h"
 
 enum ControlIDs
 {
@@ -766,6 +767,7 @@ void SectionHDRecorder::exportWAVAsFileName(const PPSystemString& fileName)
 	parameters.playMode = tracker.playerController->getPlayMode();
 	parameters.mixerShift = getSettingsMixerShift(); 
 	parameters.mixerVolume = mixerVolume;
+	parameters.limiterDrive = tracker.settingsDatabase->restore("LIMITDRIVE")->getIntValue();
 
 	mp_ubyte* muting = new mp_ubyte[moduleEditor->getNumChannels()];
 	memset(muting, 0, moduleEditor->getNumChannels());
@@ -885,6 +887,7 @@ void SectionHDRecorder::exportWAVAsSample()
 	parameters.panning = tracker.playerController->getPanningTable();
 	parameters.fromOrder = fromOrder;
 	parameters.toOrder = toOrder;
+	parameters.limiterDrive = tracker.settingsDatabase->restore("LIMITDRIVE")->getIntValue();
 
 	tracker.signalWaitState(true);
 

--- a/src/tracker/TrackerSettings.cpp
+++ b/src/tracker/TrackerSettings.cpp
@@ -75,6 +75,8 @@ void Tracker::buildDefaultSettings()
 #endif
 	settingsDatabase->store("MIXERVOLUME", 256);
 	settingsDatabase->store("MIXERSHIFT", 1);
+	settingsDatabase->store("LIMITDRIVE",0);
+	settingsDatabase->store("LIMITRESET",1);
 	settingsDatabase->store("RAMPING", 1);
 	settingsDatabase->store("INTERPOLATION", 1);
 	settingsDatabase->store("MIXERFREQ", PlayerMaster::getPreferredSampleRate());
@@ -287,6 +289,10 @@ void Tracker::applySettingByKey(PPDictionaryKey* theKey, TMixerSettings& setting
 	else if (theKey->getKey().compareTo("MIXERVOLUME") == 0)
 	{
 		settings.mixerVolume = v2;
+	}
+	else if (theKey->getKey().compareTo("LIMITDRIVE") == 0)
+	{
+		settings.limiterDrive = v2;
 	}
 	else if (theKey->getKey().compareTo("MIXERSHIFT") == 0)
 	{
@@ -710,6 +716,7 @@ void Tracker::getMixerSettingsFromDatabase(TMixerSettings& mixerSettings,
 	mixerSettings.ramping = currentSettings.restore("RAMPING")->getIntValue();
 	mixerSettings.setAudioDriverName(currentSettings.restore("AUDIODRIVER")->getStringValue());
     mixerSettings.numPlayerChannels = currentSettings.restore("XMCHANNELLIMIT")->getIntValue();
+    mixerSettings.limiterDrive = currentSettings.restore("LIMITDRIVE")->getIntValue();
 	mixerSettings.numVirtualChannels = currentSettings.restore("VIRTUALCHANNELS")->getIntValue();
 }
 

--- a/src/tracker/TrackerUpdate.cpp
+++ b/src/tracker/TrackerUpdate.cpp
@@ -45,6 +45,7 @@
 #include "SectionSamples.h"
 #include "SectionHDRecorder.h"
 #include "SectionQuickOptions.h"
+#include "SectionSettings.h"
 #include "TabHeaderControl.h"
 #include "PPOpenPanel.h"
 #include "TitlePageManager.h"
@@ -1060,6 +1061,14 @@ void Tracker::updateAfterLoad(bool loadResult, bool wasPlaying, bool wasPlayingP
 	}
 	
 	updateSongInfo(false);
+
+	if( settingsDatabase->restore("LIMITRESET")->getBoolValue() ){ // reset limiter
+		TMixerSettings newMixerSettings;
+		settingsDatabase->store("LIMITDRIVE",0);
+		sectionSettings->saveCurrentMixerSettings(newMixerSettings);
+		bool res = playerMaster->applyNewMixerSettings(newMixerSettings, true);
+		sectionSettings->update(true);
+	}
 }
 
 void Tracker::updateAfterTabSwitch()


### PR DESCRIPTION
![masteringlimiter](https://user-images.githubusercontent.com/180068/187176403-5d4d26dc-b0f8-4443-ac58-565a39c3695d.gif)

This (optional) very transparent limiter allows milkytracker to:
* output beefier, normalized mixes (the final wav-render (*))
* and/or patterncapture (sampleeditor) 
* and/or during realtime playback (**)

In simple terms: milkytracker is now able to always prevent audible clipping.

> \* = as pointed out in https://github.com/milkytracker/MilkyTracker/pull/283 summing same-rows note-on's easily produces unwanted peaks, resulting in weak mixdowns after normalizing.

> '** = playing multiple modules at the same time (liveperformance) will no longer cause peaking-problems (*) (playing 3 techno-tracks at the same time with same bpm e.g).

This feature also helps in knowing how your mod will sound when played back on broadcasted media, especially for dancemusic (drums) this is pretty important.
Setting drive to 2 will most of time output a well-balanced mix, by gently increasing soft parts & decreasing peaks (this change in loudness can be seen in the master vu-meter).
The default(!) value is **0** disables the limiter, to always ensure an honest module-playback startingpoint.

## Background

Based on all thoughts & feedback on the initial mastering section-idea (https://youtu.be/as9Ii0pt8dE?t=144), the fat has been trimmed to only one slider (ditching saturation modes, as there isn't much to saturate after limiting).
Also the 'mono mix'-feature is redundant because ctrl-shift-v (pattern capture to sample-editor) does this already.

The code is actually just `Limiter.h` along with code which makes sure the slider-value can cascade into the right places, and respond to mixingrate/buffersize changes.