### PR TITLE
sampleeditor: improved paste (mix, mix overflow, spread)

### DIFF
--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -253,6 +253,8 @@ public:
 	void minimizeSample();
 	void cropSample();
 	void clearSample();
+	void mixSpreadPasteSample();
+	void mixOverflowPasteSample();
 	void mixPasteSample();
 	void AMPasteSample();
 	void FMPasteSample();

--- a/src/tracker/SampleEditorControl.cpp
+++ b/src/tracker/SampleEditorControl.cpp
@@ -143,9 +143,11 @@ SampleEditorControl::SampleEditorControl(pp_int32 id,
 	subMenuXPaste = new PPContextMenu(8, parentScreen, this, PPPoint(0,0), TrackerConfig::colorThemeMain);
 	subMenuXPaste->setSubMenu(true);
 	subMenuXPaste->addEntry("Mix", MenuCommandIDMixPaste);
-	subMenuXPaste->addEntry("Amp Modulate", MenuCommandIDAMPaste);
-	subMenuXPaste->addEntry("Freq Modulate", MenuCommandIDFMPaste);
-	subMenuXPaste->addEntry("Phase Modulate", MenuCommandIDPHPaste);
+	subMenuXPaste->addEntry("Mix (overflow)", MenuCommandIDMixOverflowPaste);
+	subMenuXPaste->addEntry("Mix (spread)", MenuCommandIDMixSpreadPaste);
+	subMenuXPaste->addEntry("Modulate Amp", MenuCommandIDAMPaste);
+	subMenuXPaste->addEntry("Modulate Freq", MenuCommandIDFMPaste);
+	subMenuXPaste->addEntry("Modulate Phase", MenuCommandIDPHPaste);
 	subMenuXPaste->addEntry("Flanger", MenuCommandIDFLPaste);
 	subMenuXPaste->addEntry("Selective EQ" PPSTR_PERIODS, MenuCommandIDSelectiveEQ10Band);
 	subMenuXPaste->addEntry("Capture pattern" PPSTR_PERIODS, MenuCommandIDCapturePattern);
@@ -1703,6 +1705,8 @@ void SampleEditorControl::invokeContextMenu(const PPPoint& p, bool translatePoin
 	subMenuAdvanced->setState(MenuCommandIDResample, isEmptySample);
 
 	subMenuXPaste->setState(MenuCommandIDMixPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
+	subMenuXPaste->setState(MenuCommandIDMixOverflowPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
+	subMenuXPaste->setState(MenuCommandIDMixSpreadPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDAMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDFMPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
 	subMenuXPaste->setState(MenuCommandIDPHPaste, sampleEditor->clipBoardIsEmpty() || isEmptySample);
@@ -1750,7 +1754,17 @@ void SampleEditorControl::executeMenuCommand(pp_int32 commandId)
 			sampleEditor->paste();
 			break;
 
-		// mix-paste
+		// mix-paste spread
+		case MenuCommandIDMixOverflowPaste:
+			sampleEditor->mixOverflowPasteSample();
+			break;
+
+		// mix-paste spread
+		case MenuCommandIDMixSpreadPaste:
+			sampleEditor->mixSpreadPasteSample();
+			break;
+
+		// mix-paste stencil-like (preserves pitch)
 		case MenuCommandIDMixPaste:
 			sampleEditor->mixPasteSample();
 			break;

--- a/src/tracker/SampleEditorControl.h
+++ b/src/tracker/SampleEditorControl.h
@@ -280,6 +280,8 @@ private:
 	{
 		MenuCommandIDCrop = 99,
 		MenuCommandIDMixPaste,
+		MenuCommandIDMixOverflowPaste,
+		MenuCommandIDMixSpreadPaste,
 		MenuCommandIDAMPaste,
 		MenuCommandIDFMPaste,
 		MenuCommandIDPHPaste,


### PR DESCRIPTION
![paste](https://user-images.githubusercontent.com/180068/187220514-a0988416-d178-4f31-a0b7-934abf42c4b0.gif)

**Issue:** the default 'Paste > Mix' spreads the selection over the destination sample.

> This is fine, but a bit unexpected compared the normal wave-editor 'mix paste'

**Solution:** 'Paste > Mix' has been renamed to 'Paste > Mix spread' and introduced are:
* Paste > Mix (mix without spreading/stretching)
* Paste > Mix overflow (if the clipboard duration is longer, then it folds back into the beginning pacman-style)