### PR TITLE
fix: minimal non-opengl platforms can run MT again

### DIFF
--- a/docs/readme_unix
+++ b/docs/readme_unix
@@ -59,6 +59,14 @@ The screen size can be selected in the Config->Layout menu.  Fullscreen mode can
 be toggled using ALT+Return.  Note that these arguments are likely to be removed
 in the future - drop us a note if you actually need to use them.
 
+For very minimal platforms, make sure to run milkytracker in non-opengl mode:
+
+$ NO_OPENGL=1 ./milkytracker
+
+This will disable SDL2 from automatically switching to OpenGL.
+SDL2 is quite liberal in assuming that opengl is great idea.
+This can lead to immediate crashes (for example when only libGL is installed, but not GLX).
+
 
 Crash Handler
 =============

--- a/src/ppui/sdl/DisplayDevice_SDL.cpp
+++ b/src/ppui/sdl/DisplayDevice_SDL.cpp
@@ -28,6 +28,7 @@ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bp
 	size_t namelen = 0;
 	char rendername[256] = { 0 };
 	PFNGLGETSTRINGPROC glGetStringAPI = NULL;
+  bool opengl_disable = getenv("NO_OPENGL") != NULL;
 
 	for (int it = 0; it < SDL_GetNumRenderDrivers(); it++)
 	{
@@ -38,7 +39,7 @@ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bp
 		strncat(rendername, info.name, sizeof(rendername) - namelen);
 		strncat(rendername, " ", sizeof(rendername) - namelen);
 
-		if (strncmp("opengles2", info.name, 9) == 0)
+		if ( !opengl_disable && strncmp("opengles2", info.name, 9) == 0)
 		{
 			drv_index = it;
 			SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
@@ -49,7 +50,7 @@ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bp
 	}
 
 	// Create SDL window
-	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, SDL_WINDOW_OPENGL | flags);
+	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, opengl_disable ? flags : SDL_WINDOW_OPENGL | flags);
 
 	if (theWindow == NULL)
 	{

--- a/src/tracker/sdl/SDL_Main.cpp
+++ b/src/tracker/sdl/SDL_Main.cpp
@@ -824,9 +824,6 @@ myDisplayDevice = new PPDisplayDeviceFB(windowSize.width, windowSize.height, sca
 	myTrackerScreen = new PPScreen(myDisplayDevice, myTracker);
 	myTracker->setScreen(myTrackerScreen);
 
-	// Kickstart SDL event loop early so that the splash screen is made visible
-	SDL_PumpEvents();
-
 	// Startup procedure
 	myTracker->startUp(noSplash);
 
@@ -839,6 +836,11 @@ myDisplayDevice = new PPDisplayDeviceFB(windowSize.width, windowSize.height, sca
 
 	// Start capturing text input events
 	SDL_StartTextInput();
+
+
+	// Kickstart SDL event loop last to prevent overflowing message-queue on lowmem systems 
+  // splash screen will still be visible
+	SDL_PumpEvents();
 
 	ticking = true;
 }


### PR DESCRIPTION
For very minimal platforms, make sure to run milkytracker in non-opengl mode:

$ NO_OPENGL=1 ./milkytracker

> Reason: by default it requests an SDL OpenGL Context, however many minimal (embedded/SoC) systems don't run in accelerated mode. For example, using this fix I got milkytracker to run on the latest TinyCore Linux on a pentium 1 laptop.

I've read several reports of this on the milkytracker modarchive forum / https://github.com/milkytracker/MilkyTracker/issues/163 e.g.
With this fix milkytracker can once again become the helloworld 'daw' of all exotic *NIX devices out there.