### PR TITLE
Claytone/adding shortcuts (fixed conflicts) + added highlight scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ resources/pictures/docicons/osx/docerator/
 
 # Editor config files
 .vscode/
+.vs/

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -628,145 +628,169 @@
 		</table>
 		<h4>Pattern Editor:</h4>
 		<table>
-			<tr >
+			<tr>
 				<td><em>Cursor keys</em></td>
 				<td>Move around</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Tab</em></td>
 				<td>Jump to next channel</td>
 			</tr>
-			<tr >
+			<tr>
+				<td><em>Ctrl-Tab</em></td>
+				<td>Jump to previous channel</td>
+			</tr>
+			<tr>
 				<td><em>PageUp</em></td>
 				<td>Jump 16 rows up</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>PageDown</em></td>
 				<td>Jump 16 rows down</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Home</em></td>
 				<td>Jump to first row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>End</em></td>
 				<td>Jump to last row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F9</em></td>
 				<td>Jump to beginning of the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F10</em></td>
 				<td>Jump to position &frac14; through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F11</em></td>
 				<td>Jump to position halfway through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>F12</em></td>
 				<td>Jump to position &frac34; through the pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Z</em></td>
 				<td>Undo</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Y</em></td>
 				<td>Redo</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Cursor keys</em></td>
 				<td>Select block</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Alt-Cursor keys</em></td>
 				<td>Extend block</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-A</em></td>
 				<td>Select entire pattern</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-X</em></td>
 				<td>Cut</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-C</em></td>
 				<td>Copy</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-V</em></td>
 				<td>Paste</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Shift-V</em></td>
 				<td>Convert current pattern to sample</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-I</em></td>
 				<td>Interpolate values</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Delete</em></td>
 				<td>Delete note/instrument/volume/effect/parameter</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Del</em></td>
 				<td>Delete note, volume and effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Ctrl-Del</em></td>
 				<td>Delete volume and effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Alt-Delete</em></td>
 				<td>Delete effect at cursor</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Insert</em></td>
 				<td>Insert space on current track at cursor position</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Insert</em></td>
 				<td>Insert row at cursor position</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Alt-Backspace</em></td>
 				<td>Insert space on current track at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Alt-Backspace</em></td>
 				<td>Insert row at cursor position (alternative for keyboards with no Insert key)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Backspace</em></td>
 				<td>Delete previous note</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>Shift-Backspace</em></td>
 				<td>Delete previous row</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>The key right of LShift</em></td>
 				<td>Enter key-off</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>The key below Esc</em></td>
 				<td>Enter key-off (Windows only)</td>
 			</tr>
-			<tr >
+			<tr>
 				<td><em>1</em></td>
 				<td>Enter key-off (OS X only)</td>
 			</tr>
-			<tr >
-				<td><em>Alt-Minus</em></td>
+			<tr>
+				<td><em>Alt-Plus or Ctrl-J</em></td>
 				<td>Increase Add value</td>
 			</tr>
-			<tr >
-				<td><em>or Alt-Plus</em></td>
+			<tr>
+				<td><em>Alt-Minus or Ctrl-Shift-J </em></td>
 				<td>Decrease Add value</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-[</em></td>
+				<td>Increase BPM by 1</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-]</em></td>
+				<td>Decrease BPM by 1</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-Shift-[</em></td>
+				<td>Increase BPM by 5</td>
+			</tr>
+			<tr>
+				<td><em>Ctrl-Shift-]</em></td>
+				<td>Decrease BPM by 5</td>
+			</tr>
+			<tr>
+				<td><em>Alt-I</em></td>
+				<td>Load Instrument (current slot)</td>
 			</tr>
 		</table>
 		<h4>Transpose:</h4>

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -765,27 +765,27 @@
 				<td>Enter key-off (OS X only)</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Plus or Ctrl-J</em></td>
+				<td><em>Alt-Plus or Ctrl-K</em></td>
 				<td>Increase Add value</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Minus or Ctrl-Shift-J </em></td>
+				<td><em>Alt-Minus or Ctrl-J </em></td>
 				<td>Decrease Add value</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-[</em></td>
+				<td><em>Ctrl-N</em></td>
 				<td>Increase BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-]</em></td>
+				<td><em>Ctrl-B</em></td>
 				<td>Decrease BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-[</em></td>
+				<td><em>Ctrl-Shift-N</em></td>
 				<td>Increase BPM by 5</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-]</em></td>
+				<td><em>Ctrl-Shift-B</em></td>
 				<td>Decrease BPM by 5</td>
 			</tr>
 			<tr>

--- a/docs/MilkyTracker.html
+++ b/docs/MilkyTracker.html
@@ -765,27 +765,27 @@
 				<td>Enter key-off (OS X only)</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Plus or Ctrl-K</em></td>
+				<td><em>Alt-Plus or Shift-J</em></td>
 				<td>Increase Add value</td>
 			</tr>
 			<tr>
-				<td><em>Alt-Minus or Ctrl-J </em></td>
+				<td><em>Alt-Minus or Shift-H </em></td>
 				<td>Decrease Add value</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-N</em></td>
+				<td><em>Ctrl-J</em></td>
 				<td>Increase BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-B</em></td>
+				<td><em>Ctrl-H</em></td>
 				<td>Decrease BPM by 1</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-N</em></td>
+				<td><em>Ctrl-K</em></td>
 				<td>Increase BPM by 5</td>
 			</tr>
 			<tr>
-				<td><em>Ctrl-Shift-B</em></td>
+				<td><em>Ctrl-G</em></td>
 				<td>Decrease BPM by 5</td>
 			</tr>
 			<tr>

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -48,6 +48,7 @@ void PatternEditorControl::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, 0, &PatternEditorControl::eventKeyDownBinding_NextChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_NextChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierSHIFT|KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DELETE, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_DeleteNoteVolumeAndEffect);

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -37,8 +37,8 @@ void PatternEditorControl::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker = new PPKeyBindings<TPatternEditorKeyBindingHandler>;
 
 	// Key-down bindings MilkyTracker
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_LEFT, 0xFFFF, &PatternEditorControl::eventKeyDownBinding_LEFT);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_RIGHT, 0xFFFF, &PatternEditorControl::eventKeyDownBinding_RIGHT);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_LEFT, 0, &PatternEditorControl::eventKeyDownBinding_LEFT);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_RIGHT, 0, &PatternEditorControl::eventKeyDownBinding_RIGHT);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_UP, 0xFFFF, &PatternEditorControl::eventKeyDownBinding_UP);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DOWN, 0xFFFF, &PatternEditorControl::eventKeyDownBinding_DOWN);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_PRIOR, 0xFFFF, &PatternEditorControl::eventKeyDownBinding_PRIOR);
@@ -50,6 +50,8 @@ void PatternEditorControl::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_TAB, KeyModifierSHIFT|KeyModifierALT, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_LEFT, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_PreviousChannel);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_RIGHT, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_NextChannel);
 
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DELETE, KeyModifierSHIFT, &PatternEditorControl::eventKeyDownBinding_DeleteNoteVolumeAndEffect);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_DELETE, KeyModifierCTRL, &PatternEditorControl::eventKeyDownBinding_DeleteVolumeAndEffect);
@@ -70,6 +72,7 @@ void PatternEditorControl::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL, &PatternEditorControl::eventKeyCharBinding_Paste);
 	eventKeyDownBindingsMilkyTracker->addBinding('A', KeyModifierCTRL, &PatternEditorControl::eventKeyCharBinding_SelectAll);
 	eventKeyDownBindingsMilkyTracker->addBinding('M', KeyModifierSHIFT, &PatternEditorControl::eventKeyCharBinding_MuteChannel);
+	eventKeyDownBindingsMilkyTracker->addBinding('M', KeyModifierCTRL, &PatternEditorControl::eventKeyCharBinding_MuteChannel);
 	eventKeyDownBindingsMilkyTracker->addBinding('M', KeyModifierSHIFT|KeyModifierCTRL, &PatternEditorControl::eventKeyCharBinding_InvertMuting);
 	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierCTRL, &PatternEditorControl::eventKeyCharBinding_Interpolate);
 

--- a/src/tracker/ScopesControl.cpp
+++ b/src/tracker/ScopesControl.cpp
@@ -109,6 +109,7 @@ ScopesControl::ScopesControl(pp_int32 id,
 	backgroundButton = new PPButton(0, parentScreen, NULL, PPPoint(location.x, location.y), PPSize(size.width, size.height), false, false);
 	backgroundButton->setColor(PPUIConfig::getInstance()->getColor(PPUIConfig::ColorListBoxBackground));
 	backgroundButton->setInvertShading(true);
+	selectedChannel = 0;
 }
 
 ScopesControl::~ScopesControl()
@@ -250,7 +251,12 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 
 	backgroundButton->paint(g);
 
-	g->setRect(location.x, location.y, location.x + size.width+1, location.y + size.height+1);
+	PPRect scopesRect;
+	scopesRect.x1 = location.x;
+	scopesRect.y1 = location.y;
+	scopesRect.x2 = location.x + size.width+1;
+	scopesRect.y2 = location.y + size.height+1;
+	g->setRect(scopesRect);
 
 	if (border)
 	{
@@ -258,9 +264,6 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 	}
 
 	g->setRect(location.x + 2, location.y + 2, location.x + size.width - 2, location.y + size.height - 2);
-
-	//g->setColor(0,0,0);
-	//g->fill();
 
 	if (!playerController || numChannels < 2)
 		return;
@@ -356,6 +359,16 @@ void ScopesControl::paint(PPGraphicsAbstract* g)
 		pp_int32 sy = locy - channelHeight / 2 + 3;
 
 		pp_int32 sy2 = locy + channelHeight / 2 - smallFont->getCharHeight() - 1;
+		
+		if( selectedChannel == c ){
+			g->setRect(channelRects[c]);
+			PPColor highlight = g->getColor();
+			highlight.scale(0.4);
+			g->setColor( highlight );
+			g->fill();
+			g->setRect(scopesRect);
+			g->setColor( TrackerConfig::colorScopes );
+		}
 
 		if (!muteChannels[c])
 		{

--- a/src/tracker/ScopesControl.h
+++ b/src/tracker/ScopesControl.h
@@ -76,6 +76,7 @@ private:
 
 	PlayerController* playerController;
 
+	pp_int32 selectedChannel;
 	pp_int32 numChannels;
 	pp_int32 channelWidthTable[TrackerConfig::MAXCHANNELS];
 	bool onOffState[TrackerConfig::MAXCHANNELS];
@@ -148,6 +149,8 @@ public:
 
 	void setAppearance(AppearanceTypes appearance) { this->appearance = appearance; }
 	AppearanceTypes getAppearance() const { return appearance; }
+
+	void selectChannel(pp_int32 c ){ this->selectedChannel = c; }
 
 private:
 	pp_int32 pointToChannel(const PPPoint& pt);

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -583,6 +583,14 @@ private:
 	void eventKeyDownBinding_InvokePatternCapture();
 	void eventKeyDownBinding_InvokeHelp();
 
+	// brujo sauce
+	void eventKeyDownBinding_BpmPlus();
+	void eventKeyDownBinding_BpmMinus();
+	void eventKeyDownBinding_CoarseBpmPlus();
+	void eventKeyDownBinding_CoarseBpmMinus();
+	void eventKeyDownBinding_AddPlus();
+	void eventKeyDownBinding_AddMinus(); 
+	void eventKeyDownBinding_LoadInstrument();
 
 private:
 	// - friend classes --------------------------------------------------------

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -160,7 +160,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F7, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockDown);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F8, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockUp);
 
-	//eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD1, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD2, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD3, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -180,12 +180,12 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	// brujo's secret sauce 
-	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('H', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('G', KeyModifierCTRL, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('H', KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
 	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
 	// TODO: sequencer controls
 

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -180,12 +180,12 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	// brujo's secret sauce 
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmMinus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
-	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL, &Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('N', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('B', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('K', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddMinus);
 	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
 	// TODO: sequencer controls
 

--- a/src/tracker/TrackerKeyboard.cpp
+++ b/src/tracker/TrackerKeyboard.cpp
@@ -160,7 +160,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F7, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockDown);
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_F8, KeyModifierALT, &Tracker::eventKeyDownBinding_TransposeCurInsBlockUp);
 
-	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
+	//eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD0, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD1, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD2, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
 	eventKeyDownBindingsMilkyTracker->addBinding(VK_NUMPAD3, 0, &Tracker::eventKeyDownBinding_InvokeQuickChooseInstrument);	
@@ -179,6 +179,15 @@ void Tracker::initKeyBindings()
 
 	eventKeyDownBindingsMilkyTracker->addBinding('V', KeyModifierCTRL | KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
+	// brujo's secret sauce 
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL, & Tracker::eventKeyDownBinding_BpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_6 /*]*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding(VK_OEM_4 /*[*/ , KeyModifierCTRL|KeyModifierSHIFT, & Tracker::eventKeyDownBinding_CoarseBpmMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL, &Tracker::eventKeyDownBinding_AddPlus);
+	eventKeyDownBindingsMilkyTracker->addBinding('J', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_AddMinus);
+	eventKeyDownBindingsMilkyTracker->addBinding('I', KeyModifierALT, &Tracker::eventKeyDownBinding_LoadInstrument);
+	// TODO: sequencer controls
 
 	// Key-down bindings for Fasttracker
 	// tab stuff
@@ -275,6 +284,7 @@ void Tracker::initKeyBindings()
 	eventKeyDownBindingsFastTracker->addBinding('V', KeyModifierCTRL|KeyModifierSHIFT, &Tracker::eventKeyDownBinding_InvokePatternCapture);
 
 	eventKeyDownBindings = eventKeyDownBindingsMilkyTracker;
+
 }
 
 void Tracker::eventKeyDownBinding_OpenTab()
@@ -1035,4 +1045,55 @@ void Tracker::eventKeyDownBinding_InvokeHelp()
 {
   dialog = new DialogHelp(screen, responder,PP_DEFAULT_ID,"Help",true);	
   dialog->show();
+}
+
+// brujo sauce definitions
+void Tracker::eventKeyDownBinding_BpmPlus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm + 1, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_BpmMinus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm - 1, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_CoarseBpmPlus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm + 5, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_CoarseBpmMinus() {
+	moduleEditor->setChanged();
+	updateWindowTitle();
+	mp_sint32 bpm, speed;
+	playerController->getSpeed(bpm, speed);
+	playerController->setSpeed(bpm - 5, speed);
+	updateSpeed();
+}
+
+void Tracker::eventKeyDownBinding_AddPlus() {
+	getPatternEditorControl()->increaseRowInsertAdd();
+	updatePatternAddAndOctave();
+}
+
+void Tracker::eventKeyDownBinding_AddMinus() {
+	getPatternEditorControl()->decreaseRowInsertAdd();
+	updatePatternAddAndOctave();
+}
+
+void Tracker::eventKeyDownBinding_LoadInstrument() {
+	loadTypeWithDialog(FileTypes::FileTypeSongAllInstruments);
 }

--- a/src/tracker/TrackerUpdate.cpp
+++ b/src/tracker/TrackerUpdate.cpp
@@ -939,7 +939,8 @@ void Tracker::doFollowSong()
 	bool updateScopes = false;
 	if (scopesControl && scopesControl->isVisible())
 	{
-		updateScopes = scopesControl->needsUpdate();
+		updateScopes = true;
+		scopesControl->selectChannel( patternEditorControl->isActive() ? patternEditorControl->getCurrentChannel() : -1);
 		if (updateScopes && !updatePiano && !importantRefresh && !updatePlayTime && !updatePeak)
 		{
 			screen->paintControl(scopesControl);


### PR DESCRIPTION
![scopes](https://user-images.githubusercontent.com/180068/188106029-f168a344-aa8e-49dc-8108-fd6cccd86844.gif)

> (milkytracker editmode) liveperformance keys used: ctrl+ [shift] + [ m / left / right]

This basically is https://github.com/milkytracker/MilkyTracker/pull/281 but:

* mergeconflict has been solved
* ctrl+m now also toggles mute of current channel
* the current channel is highlighted in the scopes (to make muting/editing more obious)

> it's a breeze to use on a laptopkeyboard during liveperformance, especially in combination with https://github.com/milkytracker/MilkyTracker/pull/291 and https://github.com/milkytracker/MilkyTracker/pull/288