### PR TITLE
improved 'Instr backtrace'-setting

### DIFF
--- a/src/tracker/PatternEditor.cpp
+++ b/src/tracker/PatternEditor.cpp
@@ -265,23 +265,6 @@ pp_int32 PatternEditor::getCurrentActiveInstrument()
 		
 	if (!instrumentEnabled)
 		return 0;
-		
-	if (instrumentBackTrace)
-	{
-		for (pp_int32 i = cursor.row; i >= 0; i--)
-		{
-			patternTools.setPosition(pattern, cursor.channel, i);
-			
-			pp_int32 ins = patternTools.getInstrument();
-			
-			if (ins != 0)
-			{
-				return ins;
-			}
-		}
-		
-		//return -1;
-	}
 	
 	return currentInstrument;
 }

--- a/src/tracker/PatternEditor.h
+++ b/src/tracker/PatternEditor.h
@@ -277,6 +277,7 @@ public:
 	bool isInstrumentEnabled() { return instrumentEnabled; }	
 	// Intelligent instrument backtrace?
 	void setInstrumentBackTrace(bool instrumentBackTrace) { this->instrumentBackTrace = instrumentBackTrace; }
+	bool getInstrumentBackTrace(){ return this->instrumentBackTrace; }
 
 	void setCurrentOctave(pp_int32 octave) { currentOctave = octave; }
 	pp_int32 getCurrentOctave() const { return currentOctave; }

--- a/src/tracker/PatternEditorControl.h
+++ b/src/tracker/PatternEditorControl.h
@@ -511,6 +511,7 @@ public:
 	enum AdvanceCodes
 	{
 		AdvanceCodeJustUpdate,
+		AdvanceCodeColumn,
 		AdvanceCodeCursorUpWrappedStart,
 		AdvanceCodeCursorDownWrappedEnd,
 		AdvanceCodeCursorPageUpWrappedStart,

--- a/src/tracker/PatternEditorControlKeyboard.cpp
+++ b/src/tracker/PatternEditorControlKeyboard.cpp
@@ -837,6 +837,7 @@ void PatternEditorControl::eventKeyDownBinding_LEFT()
 		{
 			cursor.channel--;
 			cursor.inner = 7;
+			notifyUpdate(AdvanceCodeColumn); // needed for backtraceInstrument-feature 
 		}
 		else
 		{
@@ -865,6 +866,7 @@ void PatternEditorControl::eventKeyDownBinding_RIGHT()
 		{
 			cursor.channel++;
 			cursor.inner = 0;
+			notifyUpdate(AdvanceCodeColumn); // needed for backtraceInstrument-feature 
 		}
 		else
 		{
@@ -1314,6 +1316,7 @@ void PatternEditorControl::eventKeyDownBinding_PreviousChannel()
 				cursor.inner = 0;
 		}
 	}
+	notifyUpdate(AdvanceCodeColumn); // needed for backtraceInstrument-feature 
 }
 
 void PatternEditorControl::eventKeyDownBinding_NextChannel()
@@ -1341,6 +1344,7 @@ void PatternEditorControl::eventKeyDownBinding_NextChannel()
 				cursor.inner = 0;
 		}
 	}
+	notifyUpdate(AdvanceCodeColumn); // needed for backtraceInstrument-feature 
 }
 
 void PatternEditorControl::eventKeyDownBinding_InsertNote()

--- a/src/tracker/Tracker.cpp
+++ b/src/tracker/Tracker.cpp
@@ -1710,10 +1710,16 @@ pp_int32 Tracker::handleEvent(PPObject* sender, PPEvent* event)
 						return 1;
 						
 					// Not wrapped at all... Just calculate new position within pattern and update player position
-					case PatternEditorControl::AdvanceCodeSelectNewRow:
+					case PatternEditorControl::AdvanceCodeSelectNewRow:{
 						if (shouldFollowSong() && 
 							isEditingCurrentOrderlistPattern())
 							updateSongRow();
+						else backtraceInstrument(0,true);
+						break;
+					}
+
+					case PatternEditorControl::AdvanceCodeColumn:
+						backtraceInstrument(0,false);
 						break;
 				}
 				break;
@@ -3225,3 +3231,39 @@ void Tracker::signalWaitState(bool b)
 	screen->signalWaitState(b, TrackerConfig::colorThemeMain);	
 }
 
+
+void Tracker::backtraceInstrument(pp_uint8 channelIncrement, bool currentPosOnly ){
+	PatternEditor *p = getPatternEditor();
+	if( !p->getInstrumentBackTrace() ) return;
+	// when switching channels: visually auto-switch instrument
+	// (=less misstakes during liveperformance / ASCIISTEP16 stepsequencer mode)                
+	PatternTools patternTools;
+	PatternEditorTools::Position cursor = p->getCursor();
+	pp_int8 chan = cursor.channel + channelIncrement;
+	pp_int32 ins  = -1;
+	// backtrace last instrument on pattern-channel
+	for (pp_int32 i = cursor.row; i >= 0; i--)
+	{
+		patternTools.setPosition( p->getPattern(), chan, cursor.row);
+		if ( patternTools.getInstrument() != 0 ){
+			ins = patternTools.getInstrument();	
+			break;
+		}
+		if( currentPosOnly ) return;
+	}
+	// find future note if backtrace wasn't possible
+	if( ins == -1 && !currentPosOnly ){
+		for (pp_int32 i = cursor.row; i < p->getNumRows(); i++)
+		{
+			patternTools.setPosition( p->getPattern(), chan, i);
+			ins = patternTools.getInstrument();
+			if (ins != 0 ) break;
+		}
+	}
+	if( ins == -1 ) return;
+	getPatternEditor()->setCurrentInstrument(ins);
+	moduleEditor->setCurrentInstrumentIndex(ins-1);
+	listBoxInstruments->setSelectedIndex(ins-1);
+	updateInstrumentsListBox(true);
+	updateSampleEditor(true);
+}

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -479,6 +479,7 @@ private:
 
 	void selectNextInstrument();
 	void selectPreviousInstrument();
+	void backtraceInstrument(pp_uint8 channelIncrement, bool currentPosOnly );
 	
 	void processShortcutsFastTracker(PPEvent* event);
 

--- a/src/tracker/TrackerShortCuts.cpp
+++ b/src/tracker/TrackerShortCuts.cpp
@@ -114,6 +114,10 @@ void Tracker::processShortcutsMilkyTracker(PPEvent* event)
 				}
 				break;
 			}
+			case VK_TAB:{
+				backtraceInstrument( ::getKeyModifier() == (KeyModifierCTRL) ? -1 : +1, false);
+				break;
+			}
 
 			default:
 			{
@@ -142,8 +146,8 @@ processBindings:
 				recorderLogic->sendNoteDownToPatternEditor(event, note, patternEditorControl);	
 				break;
 			}
-
 		}
+		
 	}
 	else if (event->getID() == eKeyUp)
 	{
@@ -167,7 +171,6 @@ processBindings:
 				recorderLogic->sendNoteUpToPatternEditor(event, note, patternEditorControl);	
 			}
 		}
-		
 	}
 }
 


### PR DESCRIPTION
![backtrace-instrumentlistbox](https://user-images.githubusercontent.com/180068/188299693-ddc39e85-4a17-4f6a-b351-b36743754313.gif)

> The `Instr. backtrace`-feature (in settings) is awesome. It basically sets the instrument automatically based on previous notes on that channel.

However, it is confusing that the instrumentlistbox does not update, and still points to another instrument.
This PR adds visual feedback (instrumentlistbox+sampleditor) which solves this confusion, and makes thing much more foolproof.

> ps. the algo also look for future notes in case there are no past notes (in order to still extract an channel-instrument)