### PR TITLE
Updated README About link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ user experience of the popular DOS program Fasttracker II, with
 special playback modes available for improved Amiga ProTracker 2/3
 compatibility.
 
-Refer to http://milkytracker.titandemo.org/?about for further details.
+Refer to https://milkytracker.org/about/ for further details.
 
 Please read the file [INSTALL.md][] for installation instructions.
 


### PR DESCRIPTION
Just a small change, the link to the "About" section has been changed from the TitanDemo URL to the self-hosted one.