### PR TITLE
Compiling requires C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(MilkyTracker)
 
-# Set C++ standard to C++98
-set(CMAKE_CXX_STANDARD 98)
+# Set C++ standard to C++11
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable IDE solution folders


### PR DESCRIPTION
When compiling MilkyTracker, using the method explained in `INSTALL.md`, there is a problem.

Specifically on Linux, when compiling via `g++`:

```
/usr/include/rtmidi/RtMidi.h:137:29: note: C++11 ‘noexcept’ only available with ‘-std=c++11’ or ‘-std=gnu++11’
```

I propose a change in the `CMakeLists.txt` file that allows for use of C++11.

The change is just one line of code and one comment.

Thank you!