### PR TITLE
Switch C++ standard to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(MilkyTracker)
 
-# Set C++ standard to C++98
-set(CMAKE_CXX_STANDARD 98)
+# Set C++ standard to C++11
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable IDE solution folders


### PR DESCRIPTION
 Non-static initializers require C++11 in at least G++ 8.4.x