### PR TITLE
Enable keyjazz note row rounding

### DIFF
--- a/src/milkyplay/PlayerSTD.cpp
+++ b/src/milkyplay/PlayerSTD.cpp
@@ -1630,7 +1630,22 @@ void PlayerSTD::doTickEffect(mp_sint32 chn, TModuleChannel* chnInf, mp_sint32 ef
 			}
 			break;
 		} 
+
+		case 0x80: 
+		{
+			mp_sint32 slotsize = (numEffects*2)+2;
+			TXMPattern* pattern = &module->phead[patternIndex];
+
+			mp_sint32 pp = slotsize*chn;
+			mp_ubyte *row = pattern->patternData+
+						 (pattern->channum*slotsize*rowcnt);
 			
+			// remove noteskip meta-effect 
+			row[pp+2+2] = 0;
+			row[pp+2+2+1] = 0;
+
+			break;
+		}	
 	}
 }
 
@@ -2243,6 +2258,7 @@ void PlayerSTD::progressRow()
 
 			bool noteporta = false;
 			bool notedelay = false;
+			bool noteskip  = false;
 			
 			mp_sint32 oldIns = chnInf->ins;
 			mp_sint32 oldSmp = chnInf->smp;
@@ -2277,7 +2293,15 @@ void PlayerSTD::progressRow()
 								note = chnInf->lastnoportanote;
 						}
 						break;
+					case 0x80:
+						noteskip = true;
+						break;
 				}				
+			}
+
+			if (noteskip) {
+				// do not process anymore of this note
+				continue;
 			}
 			
 			// Check new instrument settings only if valid note or no note at all

--- a/src/tracker/RecPosProvider.cpp
+++ b/src/tracker/RecPosProvider.cpp
@@ -31,12 +31,13 @@ void RecPosProvider::getPosition(pp_int32& order, pp_int32& row)
 		order = -1;
 }
 
-void RecPosProvider::getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker)
+bool RecPosProvider::getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker)
 {
 	playerController.getPosition((mp_sint32&)order, (mp_sint32&)row, (mp_sint32&)ticker);
 	if (playerController.isPlayingPattern())
 		order = -1;
 	
+	bool rounded = false;
 	if (roundToClosestRow)
 	{
 		mp_sint32 speed, bpm;
@@ -44,6 +45,7 @@ void RecPosProvider::getPosition(pp_int32& order, pp_int32& row, pp_int32& ticke
 		// snap position to the closest row
 		if (ticker >= speed / 2)
 		{
+			rounded = true;
 			ticker = 0;
 			
 			ModuleEditor* moduleEditor = playerController.getModuleEditor();
@@ -77,4 +79,6 @@ void RecPosProvider::getPosition(pp_int32& order, pp_int32& row, pp_int32& ticke
 			}
 		}
 	}
+
+	return rounded;
 }

--- a/src/tracker/RecPosProvider.cpp
+++ b/src/tracker/RecPosProvider.cpp
@@ -47,38 +47,33 @@ bool RecPosProvider::getPosition(pp_int32& order, pp_int32& row, pp_int32& ticke
 		{
 			rounded = true;
 			ticker = 0;
-			
-			ModuleEditor* moduleEditor = playerController.getModuleEditor();
-			row++;
-			// playing pattern only?
-			if (order != -1)
-			{
-				// get pattern index of current order
-				pp_int32 patIndex = moduleEditor->getOrderPosition(order);
-				// row exceeded
-				if (row >= moduleEditor->getPattern(patIndex)->rows)
-				{
-					// wrap
-					row = 0;
-					// increase order
-					order++;
-					// order exceeded?
-					if (order >= moduleEditor->getNumOrders())
-						// wrap song
-						order = 0;
-				}
-			}
-			else
-			{
-				pp_int32 patIndex = moduleEditor->getCurrentPatternIndex();
-				if (row >= moduleEditor->getPattern(patIndex)->rows)
-					// row exceeded
-					if (row >= moduleEditor->getPattern(patIndex)->rows)
-						// wrap
-						row = 0;
-			}
+
+			incrementRow(order, row);		
 		}
 	}
 
 	return rounded;
+}
+
+void RecPosProvider::incrementRow(pp_int32& order, pp_int32& row)
+{
+    ModuleEditor* moduleEditor = playerController.getModuleEditor();
+    row++;
+    if (order != -1)
+    {
+        pp_int32 patIndex = moduleEditor->getOrderPosition(order);
+        if (row >= moduleEditor->getPattern(patIndex)->rows)
+        {
+            row = 0;
+            order++;
+            if (order >= moduleEditor->getNumOrders())
+                order = 0;
+        }
+    }
+    else
+    {
+        pp_int32 patIndex = moduleEditor->getCurrentPatternIndex();
+        if (row >= moduleEditor->getPattern(patIndex)->rows)
+            row = 0;
+    }
 }

--- a/src/tracker/RecPosProvider.h
+++ b/src/tracker/RecPosProvider.h
@@ -36,6 +36,12 @@ public:
 	{
 	}
 	
+	RecPosProvider(PlayerController& playerController, bool roundToClosestRow) :
+		playerController(playerController),
+		roundToClosestRow(roundToClosestRow)
+	{
+	}
+	
 	void getPosition(pp_int32& order, pp_int32& row);
 	bool getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker);	
  };

--- a/src/tracker/RecPosProvider.h
+++ b/src/tracker/RecPosProvider.h
@@ -44,5 +44,6 @@ public:
 	
 	void getPosition(pp_int32& order, pp_int32& row);
 	bool getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker);	
+	void incrementRow(pp_int32& order, pp_int32& row);
  };
  

--- a/src/tracker/RecPosProvider.h
+++ b/src/tracker/RecPosProvider.h
@@ -32,11 +32,11 @@ private:
 public:
 	RecPosProvider(PlayerController& playerController) :
 		playerController(playerController),
-		roundToClosestRow(false)
+		roundToClosestRow(true)
 	{
 	}
 	
 	void getPosition(pp_int32& order, pp_int32& row);
-	void getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker);	
+	bool getPosition(pp_int32& order, pp_int32& row, pp_int32& ticker);	
  };
  

--- a/src/tracker/RecorderLogic.cpp
+++ b/src/tracker/RecorderLogic.cpp
@@ -155,7 +155,7 @@ void RecorderLogic::sendNoteDownToPatternEditor(PPEvent* event, pp_int32 note, P
 		}
 		
 		
-		RecPosProvider recPosProvider(*playerController);
+		RecPosProvider recPosProvider(*playerController, roundToClosestRow && !recordNoteDelay);
 		// key is not pressed, play note and remember key + channel + position within module
 		pp_int32 pos = -1, row = 0, ticker = 0;
 		bool roundedRow = false;
@@ -208,14 +208,9 @@ void RecorderLogic::sendNoteDownToPatternEditor(PPEvent* event, pp_int32 note, P
 				if (ticker && recordNoteDelay)
 					patternEditor->writeDirectEffect(1, 0x3D, ticker > 0xf ? 0xf : ticker,
 													 chn, row, pos);
-				else if (roundedRow) {
-					pp_uint8 op = 0;
-					if (keyVolume != -1 && keyVolume >= 0 && keyVolume <= 255)
-						op = (pp_uint8)keyVolume;
-
-					patternEditor->writeDirectEffect(1, 0x80, op,
+				else if (roundedRow)
+					patternEditor->writeDirectEffect(1, 0x80, 0,
 													 chn, row, pos);
-				}
 				
 				if (keyVolume != -1 && keyVolume >= 0 && keyVolume <= 255)
 					patternEditor->writeDirectEffect(0, 0xC, (pp_uint8)keyVolume,

--- a/src/tracker/RecorderLogic.cpp
+++ b/src/tracker/RecorderLogic.cpp
@@ -261,7 +261,7 @@ void RecorderLogic::sendNoteUpToPatternEditor(PPEvent* event, pp_int32 note, Pat
 									   tracker.shouldFollowSong();
 							   				
 				bool recPat = false;
-				RecPosProvider recPosProvider(*playerController);
+				RecPosProvider recPosProvider(*playerController, roundToClosestRow && !recordNoteDelay);
 				if (isLiveRecording)
 				{
 					recPosProvider.getPosition(pos, row, ticker);
@@ -288,10 +288,18 @@ void RecorderLogic::sendNoteUpToPatternEditor(PPEvent* event, pp_int32 note, Pat
 					// if we're in the same slot => send key off by inserting key off effect
 					if (keys[i].row == row && keys[i].pos == pos)
 					{
+						// writing a note off to the same cell will overwrite the note on..
+						// skip one row
+						if (roundToClosestRow && !recordNoteDelay) {
+							recPosProvider.incrementRow(pos, row);
+							patternEditor->writeDirectNote(PatternTools::getNoteOffNote(),
+														   keys[i].channel, row, pos);
+						}
 						//mp_sint32 bpm, speed;
 						//playerController->getSpeed(bpm, speed);
-						patternEditor->writeDirectEffect(1, 0x14, ticker ? ticker : 1,
-														 keys[i].channel, row, pos);
+						else
+							patternEditor->writeDirectEffect(1, 0x14, ticker ? ticker : 1,
+															 keys[i].channel, row, pos);
 					}
 					// else write key off
 					else

--- a/src/tracker/RecorderLogic.cpp
+++ b/src/tracker/RecorderLogic.cpp
@@ -158,10 +158,11 @@ void RecorderLogic::sendNoteDownToPatternEditor(PPEvent* event, pp_int32 note, P
 		RecPosProvider recPosProvider(*playerController);
 		// key is not pressed, play note and remember key + channel + position within module
 		pp_int32 pos = -1, row = 0, ticker = 0;
+		bool roundedRow = false;
 		
 		// if we are recording we are doing a query on the current position
 		if (isLiveRecording)
-			recPosProvider.getPosition(pos, row, ticker);
+			roundedRow = recPosProvider.getPosition(pos, row, ticker);
 		else
 		{
 			pos = row = -1;
@@ -207,11 +208,19 @@ void RecorderLogic::sendNoteDownToPatternEditor(PPEvent* event, pp_int32 note, P
 				if (ticker && recordNoteDelay)
 					patternEditor->writeDirectEffect(1, 0x3D, ticker > 0xf ? 0xf : ticker,
 													 chn, row, pos);
+				else if (roundedRow) {
+					pp_uint8 op = 0;
+					if (keyVolume != -1 && keyVolume >= 0 && keyVolume <= 255)
+						op = (pp_uint8)keyVolume;
+
+					patternEditor->writeDirectEffect(1, 0x80, op,
+													 chn, row, pos);
+				}
 				
 				if (keyVolume != -1 && keyVolume >= 0 && keyVolume <= 255)
 					patternEditor->writeDirectEffect(0, 0xC, (pp_uint8)keyVolume,
 													 chn, row, pos);
-				
+
 				patternEditor->writeDirectNote(note, chn, row, pos);
 				
 				tracker.screen->paintControl(patternEditorControl);

--- a/src/tracker/RecorderLogic.h
+++ b/src/tracker/RecorderLogic.h
@@ -55,6 +55,7 @@ private:
 	bool recordMode;
 	bool recordKeyOff;
 	bool recordNoteDelay;
+	bool roundToClosestRow;
 
 public:
 	RecorderLogic(Tracker& tracker);
@@ -70,6 +71,9 @@ public:
 
 	void setRecordNoteDelay(bool recordNoteDelay) { this->recordNoteDelay = recordNoteDelay; }
 	bool setRecordNoteDelay() const { return recordNoteDelay; }
+	
+	void setRoundToClosestRow(bool roundToClosestRow) { this->roundToClosestRow = roundToClosestRow; }
+	bool getRoundToClosestRow() const { return roundToClosestRow; }
 	
 	void reset();
 	

--- a/src/tracker/SectionSettings.cpp
+++ b/src/tracker/SectionSettings.cpp
@@ -167,6 +167,7 @@ enum ControlIDs
 	CHECKBOX_SETTINGS_MULTICHN_EDIT,
 	CHECKBOX_SETTINGS_MULTICHN_RECORDKEYOFF,
 	CHECKBOX_SETTINGS_MULTICHN_RECORDNOTEDELAY,
+	CHECKBOX_SETTINGS_BUGFIX_ROUNDTOCLOSESTROW,
 
 	// Page II
 	CHECKBOX_SETTINGS_HEXCOUNT,
@@ -772,6 +773,14 @@ public:
         radioGroup->addItem("128");
         
         container->addControl(radioGroup);
+
+		y2+=65;
+		container->addControl(new PPStaticText(0, NULL, NULL, PPPoint(x2 + 2, y2 + 2), "Bugfixes", true, true));
+
+		y2+=15;
+		PPCheckBox* checkBox = new PPCheckBox(CHECKBOX_SETTINGS_BUGFIX_ROUNDTOCLOSESTROW, screen, this, PPPoint(x + 4 + 17 * 8 + 4, y2 - 1));
+		container->addControl(checkBox);
+		container->addControl(new PPCheckBoxLabel(0, NULL, this, PPPoint(x + 4, y2), "Round close. row:", checkBox, true));
     }
     
     virtual void update(PPScreen* screen, TrackerSettingsDatabase* settingsDatabase, ModuleEditor& moduleEditor)
@@ -791,6 +800,9 @@ public:
                 break;
                 
         }
+
+		v = settingsDatabase->restore("BUGFIX_ROUNDTOCLOSESTROW")->getIntValue();
+		static_cast<PPCheckBox*>(container->getControlByID(CHECKBOX_SETTINGS_BUGFIX_ROUNDTOCLOSESTROW))->checkIt(v!=0);
     }
     
 };
@@ -2029,6 +2041,16 @@ pp_int32 SectionSettings::handleEvent(PPObject* sender, PPEvent* event)
 					break;
 
 				tracker.settingsDatabase->store("MULTICHN_RECORDNOTEDELAY", (pp_int32)reinterpret_cast<PPCheckBox*>(sender)->isChecked());
+				update();
+				break;
+			}
+
+			case CHECKBOX_SETTINGS_BUGFIX_ROUNDTOCLOSESTROW:
+			{
+				if (event->getID() != eCommand)
+					break;
+
+				tracker.settingsDatabase->store("BUGFIX_ROUNDTOCLOSESTROW", (pp_int32)reinterpret_cast<PPCheckBox*>(sender)->isChecked());
 				update();
 				break;
 			}

--- a/src/tracker/TrackerSettings.cpp
+++ b/src/tracker/TrackerSettings.cpp
@@ -212,6 +212,8 @@ void Tracker::buildDefaultSettings()
 	settingsDatabase->store("MULTICHN_RECORDKEYOFF", 1);
 	// disable note delay recording
 	settingsDatabase->store("MULTICHN_RECORDNOTEDELAY", 0);
+	// enable rounding keyjazzed notes to closest row
+	settingsDatabase->store("BUGFIX_ROUNDTOCLOSESTROW", 0);
 	// Invert mousewheel?
 	settingsDatabase->store("INVERTMWHEEL", 0);
 	// Invert mousewheel zoom?  (normally wheelup zooms out: if inverted, wheelup zooms in)
@@ -584,6 +586,10 @@ void Tracker::applySettingByKey(PPDictionaryKey* theKey, TMixerSettings& setting
 	else if (theKey->getKey().compareTo("MULTICHN_RECORDNOTEDELAY") == 0)
 	{
 		recorderLogic->setRecordNoteDelay(v2 != 0);
+	}
+	else if (theKey->getKey().compareTo("BUGFIX_ROUNDTOCLOSESTROW") == 0)
+	{
+		recorderLogic->setRoundToClosestRow(v2 != 0);
 	}
 	else if (theKey->getKey().compareTo("INVERTMWHEEL") == 0)
 	{


### PR DESCRIPTION
So basically I went on to fix a milky bug that is pretty much the same as [schismtracker](https://github.com/schismtracker/schismtracker/pull/332): With keyjazz record note delay off, milky just writes incoming notes into the current active cell. This makes keyjazzing actual melodies into milky a challenge, as notes get quantized nowhere close to where I played them.

Fortunately for milky, when I went through the codebase I found that pretty much most of the code I wrote for schism for this already exist in milky. Unfortunately, it was hard-coded disabled ever since milky started using git lol.

So I went on and created a config flag for it, but first I had to fix this bug it caused: When rounding a note to the next row, the moment the player gets to actually play the cell couple of ticks later, it replays the displaced note. So I went on creating this new 'meta-effect' that just mutes the note, and deletes itself (the effect) from the pattern. This way I can disable notes until the second time they are played. More info in the commit msgs I guess.