### PR TITLE
Fix #339: enable system screensaver in SDL

### DIFF
--- a/src/tracker/sdl/SDL_Main.cpp
+++ b/src/tracker/sdl/SDL_Main.cpp
@@ -997,6 +997,9 @@ unrecognizedCommandLineSwitch:
 		}
 	}
 
+	// enable system screensaver
+	SDL_EnableScreenSaver();
+
 	// Main event loop
 	done = 0;
 	while (!done && SDL_WaitEvent(&event))


### PR DESCRIPTION
Fix issue #339: Stop SDL2 from prohibiting the system screensaver.