### PR TITLE
Fix #321 vertical scrolling.

### DIFF
--- a/src/ppui/ListBox.cpp
+++ b/src/ppui/ListBox.cpp
@@ -1026,8 +1026,10 @@ pp_int32 PPListBox::handleEvent(PPObject* sender, PPEvent* event)
 			pp_int32 visibleItems = getNumVisibleItems();
 
 			startIndex += event->getMetaData();
-			if (startIndex + visibleItems > items->size())
+			if (startIndex + visibleItems >= items->size())
 				startIndex = items->size() - visibleItems;
+			else
+				startIndex++;
 
 			float v = (float)(items->size() - visibleItems);
 
@@ -1062,6 +1064,8 @@ pp_int32 PPListBox::handleEvent(PPObject* sender, PPEvent* event)
 			startIndex -= event->getMetaData();
 			if(startIndex < 0)
 				startIndex = 0;
+			else
+				startIndex--;
 			
 			pp_int32 visibleItems = getNumVisibleItems();
 			

--- a/src/tracker/PatternEditorControlEventListener.cpp
+++ b/src/tracker/PatternEditorControlEventListener.cpp
@@ -987,13 +987,15 @@ pp_int32 PatternEditorControl::handleEvent(PPObject* sender, PPEvent* event)
 		sender == reinterpret_cast<PPObject*>(vRightScrollbar)) &&
 		event->getID() == eBarScrollDown)
 	{
-		pp_int32 scrollAmount = event->getMetaData();
+		pp_int32 scrollAmount = event->getMetaData() + 1;
 		if (properties.scrollMode != ScrollModeStayInCenter)
 		{
 			pp_int32 visibleItems = (visibleHeight) / font->getCharHeight();
 			startIndex += scrollAmount;
-			if (startIndex + visibleItems > pattern->rows)
+			if (startIndex + visibleItems >= pattern->rows)
 				startIndex = pattern->rows - visibleItems;
+			else
+				startIndex++;
 
 			float v = (float)(pattern->rows - visibleItems);
 
@@ -1013,12 +1015,14 @@ pp_int32 PatternEditorControl::handleEvent(PPObject* sender, PPEvent* event)
 			 sender == reinterpret_cast<PPObject*>(vRightScrollbar)) &&
 			 event->getID() == eBarScrollUp)
 	{
-		pp_int32 scrollAmount = event->getMetaData();
+		pp_int32 scrollAmount = event->getMetaData() + 1;
 		if (properties.scrollMode != ScrollModeStayInCenter)
 		{
 			startIndex -= scrollAmount;
 			if (startIndex < 0)
 				startIndex = 0;
+			else
+				startIndex--;
 		
 			pp_int32 visibleItems = (visibleHeight) / font->getCharHeight();
 


### PR DESCRIPTION
Fix issue #321: Vertical arrow buttons on scrollable widgets don't work.