### PR TITLE
visualize volume ramp-up in sample-editor

### DIFF
--- a/src/tracker/SampleEditor.h
+++ b/src/tracker/SampleEditor.h
@@ -245,6 +245,7 @@ public:
 	bool is16Bit() const;
 
 	pp_int32 getRelNoteNum() const;
+	pp_int32 getRelNoteSpeed() { return XModule::getc4spd(sample->relnote, sample->finetune); }
 	void increaseRelNoteNum(pp_int32 offset);
 	pp_int32 getFinetune() const;
 	void setFinetune(pp_int32 finetune);


### PR DESCRIPTION
Volume ramping will result in losing the transient of drumsamples.
In other words, the sample (transient) is not played back as drawn in the wave-editor.
At least, when it does not start with a silence-duration which equals the volume-rampup duration (5ms 'quick-ramp).
This is not/poorly communicated to the composer, which creates a disparity between expectation/reality.
Personally, I've been bitten by this quite often, as the loss of transients led me to think that I was experiencing the usual suspect: phasing-issues. 

After several brainstorms, the current focus is more on **communicating** volume ramping to the user.
That way we can leave the volume-ramping-code as-is (to reflect fasttracker II as much as possible).


To offer a more truthful experience to newcomers or ex-daw composers, simply visualizing this fact could help a lot.
