### PR TITLE
Use UTC when writing metainfo timestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ if(UNIX)
         endif()
 
         # Metainfo version and timestamp configuration, mandatory for flathub
-        string( TIMESTAMP METAINFO_DATE "%Y-%m-%d" )
+        string( TIMESTAMP METAINFO_DATE "%Y-%m-%d" UTC )
         configure_file(
             ${PROJECT_SOURCE_DIR}/resources/org.milkytracker.MilkyTracker.metainfo.xml.in
             ${PROJECT_BINARY_DIR}/resources/org.milkytracker.MilkyTracker.metainfo.xml


### PR DESCRIPTION
To help with reproducible builds[1] the `string(TIMESTAMP)` CMake function respects `$SOURCE_DATE_EPOCH` if set and uses that instead of the current time. However, the output is still sensitive to the local timezone which is enough to make the build un-reproducible.

Fix this by using UTC when getting the timestamp.

[1] https://reproducible-builds.org/