### PR TITLE
POSIX: fix build error of undeclared strcasecmp()

### DIFF
--- a/src/ppui/BasicTypes.h
+++ b/src/ppui/BasicTypes.h
@@ -43,7 +43,7 @@ typedef signed int		pp_int32;
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <string.h>
-	#include <string.h>
+	#include <strings.h>
 	#include "VirtualKeys.h"
 	#include "PPSystemString_POSIX.h"
 #endif


### PR DESCRIPTION
I tried to do an experiment and I compiled Milkytracker for CYGWIN, just to see how the code was building on POSIX. Unfortunately, the build process hangs with several errors like this one:
```
MilkyTracker/src/compression/../ppui/osinterface/posix/PPSystemString_POSIX.h: In member function ‘pp_int32 PPSystemString::compareToNoCase(const PPSystemString&) const’: MilkyTracker/src/compression/../ppui/osinterface/posix/PPSystemString_POSIX.h:147:24: error: ‘strcasecmp’ was not declared in this scope; did you mean ‘strncmp’?
  147 |                 return strcasecmp(strBuffer, str.strBuffer);
      |                        ^~~~~~~~~~
      |                        strncmp
```
After a quick check, I discovered that the error is correct.
If you open `BasicTypes.h` and you look here:

https://github.com/milkytracker/MilkyTracker/blob/60ce53e85fc23c37a15c09911125e134eaa27697/src/ppui/BasicTypes.h#L46

you will see that there are two calls to `string.h`.
Actually, `strcasecmp()` is not declared inside `string.h` but into `strings.h` (note the final 's' at the end of the file name):
https://www.man7.org/linux/man-pages/man3/strcasecmp.3.html
Probably, the intention was to add `strings.h` but it has been forgotten during the copy-paste process.
So, one call must include `string.h` and the other call must include `strings.h`.
Attached patch fixes the tiny error.
