### PR TITLE
MINGW: replace WIN32 with _WIN32 and fix build

### DIFF
--- a/src/milkyplay/MilkyPlayCommon.h
+++ b/src/milkyplay/MilkyPlayCommon.h
@@ -40,12 +40,12 @@
 #include "MilkyPlayTypes.h"
 #include "MilkyPlayResults.h"
 
-#if defined WIN32 && !defined _WIN32_WCE
+#if defined _WIN32 && !defined _WIN32_WCE
 #include <assert.h>
 #define ASSERT assert
 #endif
 
-#if defined WIN32 || defined _WIN32_WCE
+#if defined _WIN32 || defined _WIN32_WCE
 	#include <windows.h>
 #elif defined __PSP__
 	#include <assert.h>
@@ -67,7 +67,7 @@
 	#include <math.h>
 #endif
 
-#if defined WIN32 || defined _WIN32_WCE
+#if defined _WIN32 || defined _WIN32_WCE
 	typedef TCHAR SYSCHAR;
 	typedef HANDLE FHANDLE;
 #ifdef __GNUWIN32__
@@ -89,7 +89,7 @@
 
 #define MP_NUMEFFECTS 4
 
-#if (defined(WIN32) || defined(_WIN32_WCE)) && !defined(__FORCE_SDL_AUDIO__)
+#if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(__FORCE_SDL_AUDIO__)
 	#define DRIVER_WIN32
 #elif defined(__APPLE__) && !defined(__FORCE_SDL_AUDIO__)
 	#define DRIVER_OSX

--- a/src/ppui/BasicTypes.h
+++ b/src/ppui/BasicTypes.h
@@ -32,7 +32,7 @@ typedef signed int		pp_int32;
 
 #include "ScanCodes.h"
 
-#if defined(WIN32) || defined(_WIN32_WCE) 
+#if defined(_WIN32) || defined(_WIN32_WCE) 
 	#include <windows.h>
 	#include <stdio.h>
 	#define VK_ALT        VK_MENU


### PR DESCRIPTION
I tried to build MilkyTracker on MinGW, but it requires few tiny fixes for working.
There are two macros that are similar, but with different meaning:
- `_WIN32` is an intrinsic macro and it is defined directly by a C/C++ compiler for Windows.
- `WIN32` is defined when `Windows.h` is included.

Usually, the difference of these two macros is forgotten because the MSVC IDE always defines `WIN32` into the options for the preprocessor.
Instead, MinGW doesn't do it, although it is possible to solve it easily, by defining `WIN32` into the `CMAKE_CXX_FLAGS` variable of CMake.
However, it is also quite easy to fix it, because it is just needed to replace `WIN32` with `_WIN32` in few points.
This tiny patch has been tested with both MinGW and MSVC and it worked fine.