### PR TITLE
Fix blurry UI on macOS and zziplib configure error with autoconf 2.70+

### DIFF
--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -157,6 +157,9 @@ if(APPLE)
         ExternalProject_Add(zziplib
             PREFIX ${ZZIPLIB_DESTDIR}
             SOURCE_DIR ${ZZIPLIB_SUBMODULE_DIR}
+            PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/patches/ax_check_aligned_access_required.m4
+                <SOURCE_DIR>/m4/ax_check_aligned_access_required.m4
             CONFIGURE_COMMAND autoreconf -f -i
             COMMAND ./configure --prefix=${ZZIPLIB_DESTDIR}
             --without-debug --disable-dependency-tracking

--- a/src/compression/patches/ax_check_aligned_access_required.m4
+++ b/src/compression/patches/ax_check_aligned_access_required.m4
@@ -1,0 +1,64 @@
+dnl @synopsis AX_CHECK_ALIGNED_ACCESS_REQUIRED
+dnl
+dnl Copyright (C) 2006, 2009 Guido U. Draheim <guidod@gmx.de>
+dnl Copyright (C) 2010 Peter Breitenlohner <tex-live@tug.org>
+dnl
+dnl This file is free software; the copyright holders
+dnl give unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+dnl
+dnl While the x86 CPUs allow access to memory objects to be unaligned
+dnl it happens that most of the modern designs require objects to be
+dnl aligned - or they will fail with a buserror. That mode is quite known
+dnl by big-endian machines (sparc, etc) however the alpha cpu is little-
+dnl endian.
+dnl
+dnl The following function will test for aligned access to be required and
+dnl set a config.h define HAVE_ALIGNED_ACCESS_REQUIRED (name derived by
+dnl standard usage). Structures loaded from a file (or mmapped to memory)
+dnl should be accessed per-byte in that case to avoid segfault type errors.
+dnl
+dnl @category C
+dnl @author Guido U. Draheim <guidod@gmx.de>
+dnl @author Peter Breitenlohner <tex-live@tug.org>
+dnl @version 2010-02-01
+dnl @license GPLWithACException
+dnl @license BSD
+
+AC_DEFUN([AX_CHECK_ALIGNED_ACCESS_REQUIRED],
+[AC_CACHE_CHECK([if pointers to integers require aligned access],
+  [ax_cv_have_aligned_access_required],
+[if test "$cross_compiling" = yes; then
+  case "$host_cpu" in
+    alpha*|arm*|bfin*|hp*|mips*|sh*|sparc*|ia64|nv1)
+      ax_cv_have_aligned_access_required=yes ;;
+    *)
+      ax_cv_have_aligned_access_required=no ;;
+  esac
+else
+  AC_RUN_IFELSE([AC_LANG_PROGRAM([
+#include <stdio.h>
+#include <stdlib.h>
+    ],[
+  char* string = malloc(40);
+  int i;
+  for (i=0; i < 40; i++) string[[i]] = i;
+  {
+     void* s = string;
+     int* p = (int*)(s+1);
+     int* q = (int*)(s+2);
+
+     if (*p == *q) { free(string); return 1; }
+  }
+  free(string);
+  return 0;
+    ])],
+    [ax_cv_have_aligned_access_required=yes],
+    [ax_cv_have_aligned_access_required=no],
+    [ax_cv_have_aligned_access_required=no])
+fi])
+if test "$ax_cv_have_aligned_access_required" = yes ; then
+  AC_DEFINE([HAVE_ALIGNED_ACCESS_REQUIRED], [1],
+    [Define if pointers to integers require aligned access])
+fi
+])

--- a/src/tracker/cocoa/MTTrackerView.mm
+++ b/src/tracker/cocoa/MTTrackerView.mm
@@ -344,6 +344,11 @@ static BOOL drawFocusRing;
 
 		glGenerateMipmap(GL_TEXTURE_2D);
 
+		// Metal-backed OpenGL on macOS resets texture filter params after
+		// glGenerateMipmap, so re-enforce nearest-neighbor to avoid blur.
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
 		// ..not ideal! I tried some other methods including buffer objects,
 		// but nothing seems to work.  OpenGL support will be dropped on MacOS
 		// in the near future, so I don't want to spend any more time on this.


### PR DESCRIPTION
## Summary

- **macOS blur fix**: Re-apply `GL_NEAREST` texture filter parameters after each `glGenerateMipmap()` call in `MTTrackerView.mm`. The Metal-backed OpenGL driver on modern macOS silently resets texture filter parameters to their defaults (`GL_NEAREST_MIPMAP_LINEAR` / `GL_LINEAR`) when `glGenerateMipmap()` is called — causing the UI to render with bilinear interpolation instead of nearest-neighbor and appearing blurry compared to previous versions.
- **zziplib build fix**: Replace the deprecated `AC_TRY_RUN` macro with `AC_RUN_IFELSE` + `AC_LANG_PROGRAM` in `m4/ax_check_aligned_access_required.m4`. autoconf 2.70+ generates nested `case` constructs from `AC_TRY_RUN` that produce a `syntax error near unexpected token ';;'` in `/bin/sh` on macOS, preventing zziplib from configuring.

## Test plan

- [ ] Build on macOS with autoconf 2.70+ — zziplib configure step should complete without syntax errors
- [ ] Run MilkyTracker on a Retina display — UI should appear sharp with pixel-perfect nearest-neighbor scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)